### PR TITLE
Using left outer joins for traversing navigation properties

### DIFF
--- a/NHibernate.OData.Test/Criterions/NestedMembers.cs
+++ b/NHibernate.OData.Test/Criterions/NestedMembers.cs
@@ -23,7 +23,7 @@ namespace NHibernate.OData.Test.Criterions
         [Test]
         public void OrderByChild()
         {
-            VerifyOrdered<Parent>("$orderby=Child/Name desc", q => q.Where(p => p.Child != null).OrderBy(p => p.Name).Desc);
+            VerifyOrdered<Parent>("$orderby=Child/Name desc", q => q.OrderBy(p => p.Name).Desc, null, x => x.Child == null);
         }
 
         [Test]

--- a/NHibernate.OData.Test/Issues/Issue6Fixture.cs
+++ b/NHibernate.OData.Test/Issues/Issue6Fixture.cs
@@ -29,11 +29,12 @@ namespace NHibernate.OData.Test.Issues
         {
             VerifyOrdered<Parent>(
                 "$orderby=child/name desc",
-                q => q.Where(p => p.Child != null).OrderBy(p => p.Name).Desc,
+                q => q.OrderBy(p => p.Name).Desc,
                 new ODataParserConfiguration
                 {
                     CaseSensitive = false
-                }
+                },
+                x => x.Child == null
             );
         }
     }

--- a/NHibernate.OData/ODataExpression.cs
+++ b/NHibernate.OData/ODataExpression.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using NHibernate.Criterion;
+using NHibernate.SqlCommand;
 
 namespace NHibernate.OData
 {
@@ -101,7 +102,7 @@ namespace NHibernate.OData
 
             foreach (var alias in _normalizeVisitor.Aliases)
             {
-                criteria.CreateAlias(alias.Key, alias.Value);
+                criteria.CreateAlias(alias.Key, alias.Value, JoinType.LeftOuterJoin);
             }
 
             if (_criterion != null)


### PR DESCRIPTION
Right now NHibernate aliases are constructed using `public ICriteria CreateAlias(string associationPath, string alias)` method which creates an inner join.

I think that left outer joins should be used for traversing navigation properties because using an inner join will result in all parent entities with null reference to child entity to be excluded from the result set when a navigation property is used in `$filter` or `$orderby` parameters.

For example, the query `$orderby=child/name` (without `$filter`) excludes all parent entities with `Child == null` which is definitely incorrect as `$orderby` shouldn't affect count of selected entities.

This pull request changes join type to left and fixes unit tests. 
I hope you will find it useful.
