### PR TITLE
Add support for NHibernate components

### DIFF
--- a/NHibernate.OData.Test/Criterions/Components.cs
+++ b/NHibernate.OData.Test/Criterions/Components.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NHibernate.OData.Test.Domain;
+using NHibernate.OData.Test.Support;
+using NUnit.Framework;
+
+namespace NHibernate.OData.Test.Criterions
+{
+    [TestFixture]
+    internal class Components : DomainTestFixture
+    {
+        [Test]
+        public void SelectByComponentMemberEq()
+        {
+            Verify(
+                "Component/Value eq 'Value 1'",
+                Session.QueryOver<Child>().Where(x => x.Name == "Child 1").List()
+            );
+        }
+
+        [Test]
+        public void SelectByChildComponentMemberEq()
+        {
+            Verify(
+                "Child/Component/Value eq 'Value 1'",
+                Session.QueryOver<Parent>().Where(x => x.Name == "Parent 1").List()
+            );
+        }
+
+        // In NHibernate a component is considered to be null when all of its mapped properties are null
+        [Test]
+        public void SelectByComponentIsNull()
+        {
+            Verify(
+                "Component eq null",
+                Session.QueryOver<Child>().Where(x => x.Name == "Child 10").List()
+            );
+        }
+
+        [Test]
+        public void SelectByChildComponentIsNull()
+        {
+            Verify(
+                "Child/Component eq null",
+                Session.QueryOver<Parent>().Where(x => x.Name == "Parent 10").List()
+            );
+        }
+    }
+}

--- a/NHibernate.OData.Test/Domain/Child.cs
+++ b/NHibernate.OData.Test/Domain/Child.cs
@@ -13,6 +13,8 @@ namespace NHibernate.OData.Test.Domain
 
         public virtual int Int32 { get; set; }
 
+        public virtual Component Component { get; set; }
+
         public override string ToString()
         {
             return Name;

--- a/NHibernate.OData.Test/Domain/Component.cs
+++ b/NHibernate.OData.Test/Domain/Component.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NHibernate.OData.Test.Domain
+{
+    public class Component
+    {
+        public virtual string Value { get; set; }
+    }
+}

--- a/NHibernate.OData.Test/Domain/Model.hbm.xml
+++ b/NHibernate.OData.Test/Domain/Model.hbm.xml
@@ -16,5 +16,8 @@
     </id>
     <property name="Name" type="string" />
     <property name="Int32" type="int" />
+    <component name="Component">
+      <property name="Value" type="string"/>
+    </component>
   </class>
 </hibernate-mapping>

--- a/NHibernate.OData.Test/NHibernate.OData.Test.csproj
+++ b/NHibernate.OData.Test/NHibernate.OData.Test.csproj
@@ -63,12 +63,14 @@
     <Compile Include="Criterions\Arithmetics.cs" />
     <Compile Include="Criterions\Casting.cs" />
     <Compile Include="Criterions\Comparisons.cs" />
+    <Compile Include="Criterions\Components.cs" />
     <Compile Include="Criterions\DateParts.cs" />
     <Compile Include="Criterions\IsOfs.cs" />
     <Compile Include="Criterions\Logicals.cs" />
     <Compile Include="Criterions\NestedMembers.cs" />
     <Compile Include="Criterions\QueryTest.cs" />
     <Compile Include="Criterions\Strings.cs" />
+    <Compile Include="Domain\Component.cs" />
     <Compile Include="Domain\IEntity.cs" />
     <Compile Include="Interface\EntityNameInterface.cs" />
     <Compile Include="Interface\ParsedQueryString.cs" />

--- a/NHibernate.OData.Test/Support/DomainTestFixture.cs
+++ b/NHibernate.OData.Test/Support/DomainTestFixture.cs
@@ -65,8 +65,15 @@ namespace NHibernate.OData.Test.Support
                     var child = new Child
                     {
                         Name = "Child " + i,
-                        Int32 = i
+                        Int32 = i,
+                        Component = new Component
+                        {
+                            Value = "Value " + i
+                        }
                     };
+
+                    if (i == 10)
+                        child.Component = null;
 
                     session.Save(child);
 

--- a/NHibernate.OData.Test/Support/NormalizedTestFixture.cs
+++ b/NHibernate.OData.Test/Support/NormalizedTestFixture.cs
@@ -9,7 +9,7 @@ namespace NHibernate.OData.Test.Support
     {
         protected override void Verify(Expression actual, Expression expected)
         {
-            base.Verify(actual.Visit(new AliasingNormalizeVisitor(null, true)), expected);
+            base.Verify(actual.Visit(new AliasingNormalizeVisitor(new System.Type[0],  null, true)), expected);
         }
 
         protected void Verify(string source, object value)
@@ -22,7 +22,7 @@ namespace NHibernate.OData.Test.Support
 
         protected override Expression VerifyThrows(Expression expression)
         {
-            return expression.Visit(new AliasingNormalizeVisitor(null, true));
+            return expression.Visit(new AliasingNormalizeVisitor(new System.Type[0], null, true));
         }
     }
 }

--- a/NHibernate.OData/ODataExpression.cs
+++ b/NHibernate.OData/ODataExpression.cs
@@ -15,26 +15,29 @@ namespace NHibernate.OData
         private OrderBy[] _orderBys;
         private readonly AliasingNormalizeVisitor _normalizeVisitor;
         private ODataParserConfiguration _configuration;
+        private readonly IList<System.Type> _mappedClasses;
 
-        private ODataExpression(System.Type persistentClass, ODataParserConfiguration configuration)
+        private ODataExpression(IList<System.Type> mappedClasses, System.Type persistentClass, ODataParserConfiguration configuration)
         {
+            Require.NotNull(mappedClasses, "mappedClasses");
             Require.NotNull(persistentClass, "persistentClass");
             Require.NotNull(configuration, "configuration");
 
+            _mappedClasses = mappedClasses;
             _configuration = configuration;
-            _normalizeVisitor = new AliasingNormalizeVisitor(persistentClass, configuration.CaseSensitive);
+            _normalizeVisitor = new AliasingNormalizeVisitor(mappedClasses, persistentClass, configuration.CaseSensitive);
         }
 
-        public ODataExpression(string queryString, System.Type persistentClass, ODataParserConfiguration configuration)
-            : this(persistentClass, configuration)
+        public ODataExpression(IList<System.Type> _mappedClasses, string queryString, System.Type persistentClass, ODataParserConfiguration configuration)
+            : this(_mappedClasses, persistentClass, configuration)
         {
             Require.NotNull(queryString, "queryString");
 
             ParseQueryString(queryString);
         }
 
-        public ODataExpression(IEnumerable<KeyValuePair<string, string>> queryStringParts, System.Type persistentClass, ODataParserConfiguration configuration)
-            : this(persistentClass, configuration)
+        public ODataExpression(IList<System.Type> _mappedClasses, IEnumerable<KeyValuePair<string, string>> queryStringParts, System.Type persistentClass, ODataParserConfiguration configuration)
+            : this(_mappedClasses, persistentClass, configuration)
         {
             Require.NotNull(queryStringParts, "queryStringParts");
 

--- a/NHibernate.OData/ODataParser.cs
+++ b/NHibernate.OData/ODataParser.cs
@@ -57,7 +57,7 @@ namespace NHibernate.OData
 
             var persistenceClass = ResolvePersistenceClass(session, entityName);
 
-            var expression = new ODataExpression(queryString, persistenceClass, configuration ?? new ODataParserConfiguration());
+            var expression = new ODataExpression(GetMappedClasses(session), queryString, persistenceClass, configuration ?? new ODataParserConfiguration());
 
             return expression.BuildCriteria(session, persistenceClass);
         }
@@ -80,7 +80,7 @@ namespace NHibernate.OData
 
             var persistenceClass = ResolvePersistenceClass(session, entityName);
 
-            var expression = new ODataExpression(queryStringParts, persistenceClass, configuration ?? new ODataParserConfiguration());
+            var expression = new ODataExpression(GetMappedClasses(session), queryStringParts, persistenceClass, configuration ?? new ODataParserConfiguration());
 
             return expression.BuildCriteria(session, persistenceClass);
         }
@@ -100,6 +100,11 @@ namespace NHibernate.OData
             }
 
             throw new QueryException("Cannot resolve entity name '{0}'", entityName);
+        }
+
+        private static IList<System.Type> GetMappedClasses(ISession session)
+        {
+            return session.SessionFactory.GetAllClassMetadata().Values.Select(x => x.GetMappedClass(EntityMode.Poco)).ToList();
         }
 
         /// <summary>
@@ -146,7 +151,7 @@ namespace NHibernate.OData
             Require.NotNull(persistentClass, "persistentClass");
             Require.NotNull(queryString, "queryString");
 
-            var expression = new ODataExpression(queryString, persistentClass, configuration ?? new ODataParserConfiguration());
+            var expression = new ODataExpression(GetMappedClasses(session), queryString, persistentClass, configuration ?? new ODataParserConfiguration());
 
             return expression.BuildCriteria(session, persistentClass);
         }
@@ -167,7 +172,7 @@ namespace NHibernate.OData
             Require.NotNull(persistentClass, "persistentClass");
             Require.NotNull(queryStringParts, "queryStringParts");
 
-            var expression = new ODataExpression(queryStringParts, persistentClass, configuration ?? new ODataParserConfiguration());
+            var expression = new ODataExpression(GetMappedClasses(session), queryStringParts, persistentClass, configuration ?? new ODataParserConfiguration());
 
             return expression.BuildCriteria(session, persistentClass);
         }


### PR DESCRIPTION
This pull request adds support for [NHibernate components](http://nhforge.org/doc/nh/en/index.html#mapping-declaration-component).

In order to implement this, I pass a list of all persistent classes (extracted from `ISessionFactory`'s class metadata) down to `AliasingNormalizeVisitor`. Then, when members are visited, I check whether the member's type is a persistent class. If it is a persistent class and it isn't the last member, then an alias is constructed, otherwise the member path is left intact.

For example, consider the `Child/Component/Value` member expression.
The `Child` is a persistent class, so we create an alias for it: `t1 => Child`, and replace the result path with this alias: `t1`.
The `Component` is not a persistent class, so we just concat the result path with it: `t1.Component`.
The `Value` is not a persistent class, we concat the result path with it: `t1.Component.Value`.

The resolved member expression is `t1.Component.Value` and the only created alias is `t1 => Child`.

I don't think this is a breaking change because component expressions weren't working, so I didn't add new configuration options.
