### PR TITLE
Timezone support

### DIFF
--- a/NHibernate.OData.Test/Lexer/LiteralParsing.cs
+++ b/NHibernate.OData.Test/Lexer/LiteralParsing.cs
@@ -92,5 +92,15 @@ namespace NHibernate.OData.Test.Lexer
         {
             Verify("null", new object[] { null });
         }
+
+        [Test]
+        public void DateTime()
+        {
+            Verify("datetime'2014-01-02T3:04'", new DateTime(2014, 1, 2, 3, 4, 0));
+            Verify("datetime'2014-01-02T03:04'", new DateTime(2014, 1, 2, 3, 4, 0));
+            Verify("datetime'2014-01-02T03:04:05'", new DateTime(2014, 1, 2, 3, 4, 5));
+            Verify("datetime'2014-01-02T03:04:05.5000'", new DateTime(2014, 1, 2, 3, 4, 5, 5000 / 1000));
+            Verify("datetime'2014-01-02T03:04:05.0002000'", new DateTime(2014, 1, 2, 3, 4, 5, 2000 / 1000));
+        }
     }
 }

--- a/NHibernate.OData.Test/Lexer/LiteralParsing.cs
+++ b/NHibernate.OData.Test/Lexer/LiteralParsing.cs
@@ -101,6 +101,10 @@ namespace NHibernate.OData.Test.Lexer
             Verify("datetime'2014-01-02T03:04:05'", new DateTime(2014, 1, 2, 3, 4, 5));
             Verify("datetime'2014-01-02T03:04:05.5000'", new DateTime(2014, 1, 2, 3, 4, 5, 5000 / 1000));
             Verify("datetime'2014-01-02T03:04:05.0002000'", new DateTime(2014, 1, 2, 3, 4, 5, 2000 / 1000));
+
+            Verify("datetime'2014-01-02T3:04Z'", new DateTimeOffset(2014, 1, 2, 3, 4, 0, TimeSpan.Zero).UtcDateTime);
+            Verify("datetime'2014-01-02T3:04+01:30'", new DateTimeOffset(2014, 1, 2, 3, 4, 0, TimeSpan.FromMinutes(90)).UtcDateTime);
+            Verify("datetime'2014-01-02T3:04-01:30'", new DateTimeOffset(2014, 1, 2, 3, 4, 0, TimeSpan.FromMinutes(-90)).UtcDateTime);
         }
     }
 }

--- a/NHibernate.OData/Lexer.cs
+++ b/NHibernate.OData/Lexer.cs
@@ -10,7 +10,7 @@ namespace NHibernate.OData
     internal class Lexer
     {
         private static readonly CultureInfo ParseCulture = CultureInfo.InvariantCulture;
-        private static readonly Regex DateTimeRegex = new Regex("^(\\d{4})-(\\d{1,2})-(\\d{1,2})T(\\d{1,2}):(\\d{2})(?::(\\d{2})(?:\\.(\\d{1,7}))?)?$");
+        private static readonly Regex DateTimeRegex = new Regex("^(\\d{4})-(\\d{1,2})-(\\d{1,2})T(\\d{1,2}):(\\d{2})(?::(\\d{2})(?:\\.(\\d{1,7}))?)?(Z|(?:[+-](\\d{1,2}):(\\d{2})))?$");
         private static readonly Regex GuidRegex = new Regex("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$");
         private static readonly Regex DurationRegex = new Regex("^(-)?P(?:(\\d+)Y)?(?:(\\d+)M)?(?:(\\d+)D)?T?(?:(\\d+)H)?(?:(\\d+)M)?(?:(\\d+(?:\\.\\d*)?)S)?$");
         private readonly string _source;
@@ -483,9 +483,38 @@ namespace NHibernate.OData
                 int second = match.Groups[6].Value.Length > 0 ? int.Parse(match.Groups[6].Value, ParseCulture) : 0;
                 int nanoSecond = match.Groups[7].Value.Length > 0 ? int.Parse(match.Groups[7].Value, ParseCulture) : 0;
 
-                // We let DateTime take care of validating the input.
+                // Parse timezone offset
 
-                return new LiteralToken(new DateTime(year, month, day, hour, minute, second, nanoSecond / 1000), LiteralType.DateTime);
+                string timeZoneString = match.Groups[8].Value;
+                TimeSpan? timeZoneOffset = null;
+
+                if (timeZoneString.Equals("Z", StringComparison.Ordinal))
+                    timeZoneOffset = TimeSpan.Zero;
+                else if (timeZoneString.Length > 0)
+                {
+                    int tzHour = int.Parse(match.Groups[9].Value, ParseCulture);
+                    int tzMinute = int.Parse(match.Groups[10].Value, ParseCulture);
+
+                    timeZoneOffset = new TimeSpan(tzHour, tzMinute, 0);
+
+                    if (timeZoneString[0] == '-')
+                        timeZoneOffset = -timeZoneOffset;
+                }
+
+                // We let DateTime take care of validating the input.
+                // If the timezone was not specified, default to local timezone
+
+                DateTimeOffset dateTimeOffset = new DateTimeOffset(
+                    year, month, day, hour, minute, second, nanoSecond / 1000,
+                    timeZoneOffset ?? DateTimeOffset.Now.Offset
+                );
+
+                // If the timezone was specified, return it as UTC DateTime;
+                // else return it as is (DateTimeKind.Unspecified)
+
+                DateTime dateTime = timeZoneOffset != null ? dateTimeOffset.UtcDateTime : dateTimeOffset.DateTime;
+
+                return new LiteralToken(dateTime, LiteralType.DateTime);
             }
             else
             {

--- a/NHibernate.OData/Lexer.cs
+++ b/NHibernate.OData/Lexer.cs
@@ -10,7 +10,7 @@ namespace NHibernate.OData
     internal class Lexer
     {
         private static readonly CultureInfo ParseCulture = CultureInfo.InvariantCulture;
-        private static readonly Regex DateTimeRegex = new Regex("^(\\d{4})-(\\d{1,2})-(\\d{1,2})T(\\d{1,22}):(\\d{2})(?::(\\d{2})(?:\\.(\\d{7}))?)?$");
+        private static readonly Regex DateTimeRegex = new Regex("^(\\d{4})-(\\d{1,2})-(\\d{1,2})T(\\d{1,2}):(\\d{2})(?::(\\d{2})(?:\\.(\\d{1,7}))?)?$");
         private static readonly Regex GuidRegex = new Regex("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$");
         private static readonly Regex DurationRegex = new Regex("^(-)?P(?:(\\d+)Y)?(?:(\\d+)M)?(?:(\\d+)D)?T?(?:(\\d+)H)?(?:(\\d+)M)?(?:(\\d+(?:\\.\\d*)?)S)?$");
         private readonly string _source;


### PR DESCRIPTION
I added support for timezones in DateTime literals: `datetime'2014-01-02T3:04+01:30'`. 

If the timezone was not provided, the behaviour is unchanged: the DateTimes are returned as is with `DateTimeKind.Unspecified`.

If the timezone was provided (either `Z` for UTC or `+/-HH:MM` for UTC offset), the DateTime is adjusted to the UTC timezone and returned with `DateTimeKind.Utc`.