### PR TITLE
Dynamic component support

### DIFF
--- a/NHibernate.OData.Test/Criterions/Components.cs
+++ b/NHibernate.OData.Test/Criterions/Components.cs
@@ -21,6 +21,15 @@ namespace NHibernate.OData.Test.Criterions
         }
 
         [Test]
+        public void SelectByComponentMemberIsNull()
+        {
+            Verify(
+                "Component/Value eq null",
+                Session.QueryOver<Child>().Where(x => x.Name == "Child 10").List()
+            );
+        }
+
+        [Test]
         public void SelectByChildComponentMemberEq()
         {
             Verify(
@@ -36,6 +45,15 @@ namespace NHibernate.OData.Test.Criterions
             Verify(
                 "Component eq null",
                 Session.QueryOver<Child>().Where(x => x.Name == "Child 10").List()
+            );
+        }
+
+        [Test]
+        public void SelectByComponentIsNotNull()
+        {
+            Verify(
+                "Component ne null",
+                Session.QueryOver<Child>().Where(x => x.Component != null).List()
             );
         }
 

--- a/NHibernate.OData.Test/Criterions/DynamicComponents.cs
+++ b/NHibernate.OData.Test/Criterions/DynamicComponents.cs
@@ -47,5 +47,39 @@ namespace NHibernate.OData.Test.Criterions
                 Session.QueryOver<Parent>().Where(x => x.Name == "Parent 10").List()
             );
         }
+
+        [Test]
+        public void SelectByComponentManyToOneMember()
+        {
+            Verify(
+                "Child/DynamicComponent/DynamicChildRef/Name eq 'Child 4'",
+                Session.QueryOver<Parent>().Where(x => x.Name == "Parent 5").List()
+            );
+        }
+
+        [Test]
+        public void SelectByMultipleConditionsOnManyToOneMember()
+        {
+            Verify(
+                "(Child/DynamicComponent/DynamicChildRef/Name eq 'Child 4') or (Child/DynamicComponent/DynamicChildRef/Name eq 'Child 5')",
+                Session.QueryOver<Parent>().Where(x => x.Name == "Parent 5" || x.Name == "Parent 6").List()
+            );
+        }
+
+        [Test]
+        public void SelectByComponentManyToOneMemberCaseInsensitive()
+        {
+            Verify(
+                "child/dynamiccomponent/dynamicchildref/name eq 'Child 4'",
+                Session.QueryOver<Parent>().Where(x => x.Name == "Parent 5").List(),
+                new ODataParserConfiguration { CaseSensitive = false }
+            );
+        }
+
+        [Test]
+        public void ThrowsOnUnknownComponentMember()
+        {
+            VerifyThrows<Parent>("Child/DynamicComponent/UnknownMember eq 10", typeof(QueryException));
+        }
     }
 }

--- a/NHibernate.OData.Test/Criterions/DynamicComponents.cs
+++ b/NHibernate.OData.Test/Criterions/DynamicComponents.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NHibernate.OData.Test.Domain;
+using NHibernate.OData.Test.Support;
+using NUnit.Framework;
+
+namespace NHibernate.OData.Test.Criterions
+{
+    [TestFixture]
+    internal class DynamicComponents : DomainTestFixture
+    {
+        [Test]
+        public void SelectByComponentMemberEq()
+        {
+            Verify(
+                "DynamicComponent/DynamicString eq 'Value 1'",
+                Session.QueryOver<Child>().Where(x => x.Name == "Child 1").List()
+            );
+        }
+
+        [Test]
+        public void SelectByChildComponentMemberEq()
+        {
+            Verify(
+                "Child/DynamicComponent/DynamicString eq 'Value 1'",
+                Session.QueryOver<Parent>().Where(x => x.Name == "Parent 1").List()
+            );
+        }
+
+        // In NHibernate a component is considered to be null when all of its mapped properties are null
+        [Test]
+        public void SelectByComponentIsNull()
+        {
+            Verify(
+                "DynamicComponent eq null",
+                Session.QueryOver<Child>().Where(x => x.Name == "Child 10").List()
+            );
+        }
+
+        [Test]
+        public void SelectByChildComponentIsNull()
+        {
+            Verify(
+                "Child/DynamicComponent eq null",
+                Session.QueryOver<Parent>().Where(x => x.Name == "Parent 10").List()
+            );
+        }
+    }
+}

--- a/NHibernate.OData.Test/Domain/Child.cs
+++ b/NHibernate.OData.Test/Domain/Child.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,6 +15,8 @@ namespace NHibernate.OData.Test.Domain
         public virtual int Int32 { get; set; }
 
         public virtual Component Component { get; set; }
+
+        public virtual IDictionary DynamicComponent { get; set; }
 
         public override string ToString()
         {

--- a/NHibernate.OData.Test/Domain/Component.cs
+++ b/NHibernate.OData.Test/Domain/Component.cs
@@ -8,5 +8,6 @@ namespace NHibernate.OData.Test.Domain
     public class Component
     {
         public virtual string Value { get; set; }
+        public virtual int? IntValue { get; set; }
     }
 }

--- a/NHibernate.OData.Test/Domain/Model.hbm.xml
+++ b/NHibernate.OData.Test/Domain/Model.hbm.xml
@@ -18,6 +18,7 @@
     <property name="Int32" type="int" />
     <component name="Component">
       <property name="Value" type="string"/>
+      <property name="IntValue" type="int"/>
     </component>
   </class>
 </hibernate-mapping>

--- a/NHibernate.OData.Test/Domain/Model.hbm.xml
+++ b/NHibernate.OData.Test/Domain/Model.hbm.xml
@@ -23,6 +23,7 @@
     <dynamic-component name="DynamicComponent">
       <property name="DynamicString" type="string"/>
       <property name="DynamicInt" type="int"/>
+      <many-to-one name="DynamicChildRef" class="Child"/>
     </dynamic-component>
   </class>
 </hibernate-mapping>

--- a/NHibernate.OData.Test/Domain/Model.hbm.xml
+++ b/NHibernate.OData.Test/Domain/Model.hbm.xml
@@ -20,5 +20,9 @@
       <property name="Value" type="string"/>
       <property name="IntValue" type="int"/>
     </component>
+    <dynamic-component name="DynamicComponent">
+      <property name="DynamicString" type="string"/>
+      <property name="DynamicInt" type="int"/>
+    </dynamic-component>
   </class>
 </hibernate-mapping>

--- a/NHibernate.OData.Test/NHibernate.OData.Test.csproj
+++ b/NHibernate.OData.Test/NHibernate.OData.Test.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Criterions\Arithmetics.cs" />
     <Compile Include="Criterions\Casting.cs" />
     <Compile Include="Criterions\Comparisons.cs" />
+    <Compile Include="Criterions\DynamicComponents.cs" />
     <Compile Include="Criterions\Components.cs" />
     <Compile Include="Criterions\DateParts.cs" />
     <Compile Include="Criterions\IsOfs.cs" />

--- a/NHibernate.OData.Test/Support/DomainTestFixture.cs
+++ b/NHibernate.OData.Test/Support/DomainTestFixture.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -69,11 +70,19 @@ namespace NHibernate.OData.Test.Support
                         Component = new Component
                         {
                             Value = "Value " + i
+                        },
+                        DynamicComponent = new Hashtable
+                        {
+                            { "DynamicString", "Value " + i },
+                            { "DynamicInt", i }
                         }
                     };
 
                     if (i == 10)
+                    {
                         child.Component = null;
+                        child.DynamicComponent = null;
+                    }
 
                     session.Save(child);
 

--- a/NHibernate.OData.Test/Support/DomainTestFixture.cs
+++ b/NHibernate.OData.Test/Support/DomainTestFixture.cs
@@ -59,6 +59,8 @@ namespace NHibernate.OData.Test.Support
             {
                 string lengthString = "";
 
+                Child previousChild = null;
+
                 for (int i = 1; i <= 10; i++)
                 {
                     lengthString += ((char)('A' + (i - 1))).ToString();
@@ -74,7 +76,8 @@ namespace NHibernate.OData.Test.Support
                         DynamicComponent = new Hashtable
                         {
                             { "DynamicString", "Value " + i },
-                            { "DynamicInt", i }
+                            { "DynamicInt", i },
+                            { "DynamicChildRef", previousChild },
                         }
                     };
 
@@ -94,6 +97,8 @@ namespace NHibernate.OData.Test.Support
                         LengthString = lengthString,
                         DateTime = new DateTime(2000 + i, i, i, i, i, i)
                     });
+
+                    previousChild = child;
                 }
 
                 session.Save(new Parent

--- a/NHibernate.OData/AliasingNormalizeVisitor.cs
+++ b/NHibernate.OData/AliasingNormalizeVisitor.cs
@@ -62,7 +62,7 @@ namespace NHibernate.OData
                 {
                     mappedClass = _context.MappedClassMetadata[type];
 
-                    string path = string.Concat(lastAlias != null ? lastAlias + "." : null, sb.ToString());
+                    string path = (lastAlias != null ? lastAlias + "." : null) + sb;
 
                     if (!Aliases.TryGetValue(path, out lastAlias))
                     {
@@ -76,7 +76,7 @@ namespace NHibernate.OData
 
             return new ResolvedMemberExpression(
                 expression.MemberType,
-                string.Concat(lastAlias != null ? lastAlias + "." : null, sb.ToString())
+                (lastAlias != null ? lastAlias + "." : null) + sb
             );
         }
 
@@ -88,7 +88,7 @@ namespace NHibernate.OData
             // Dynamic component support
             if (type == typeof(IDictionary) && mappedClass != null)
             {
-                string fullPath = string.Concat(mappedClassPath, ".", name);
+                string fullPath = mappedClassPath + "." + name;
 
                 var dynamicProperty = mappedClass.FindDynamicComponentProperty(fullPath, _caseSensitive);
 

--- a/NHibernate.OData/AliasingNormalizeVisitor.cs
+++ b/NHibernate.OData/AliasingNormalizeVisitor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -77,7 +78,7 @@ namespace NHibernate.OData
 
         private string ResolveName(string name, ref System.Type type)
         {
-            if (type == null)
+            if (type == null || typeof(IDictionary).IsAssignableFrom(type))
                 return name;
 
             var bindingFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;

--- a/NHibernate.OData/CriterionVisitor.cs
+++ b/NHibernate.OData/CriterionVisitor.cs
@@ -42,12 +42,29 @@ namespace NHibernate.OData
 
                 left = ProjectionVisitor.CreateProjection(leftExpression);
 
-                switch (expression.Operator)
+                // If the restriction is applied to a component ("Component eq null"), 
+                // we should use Restrictions.IsNull(string propertyName) overload, otherwise NHibernate will raise an exception
+
+                IPropertyProjection property = left as IPropertyProjection;
+
+                if (property != null)
                 {
-                    case Operator.Eq: return Restrictions.IsNull(left);
-                    case Operator.Ne: return Restrictions.IsNotNull(left);
-                    default: throw new NotSupportedException();
+                    switch (expression.Operator)
+                    {
+                        case Operator.Eq: return Restrictions.IsNull(property.PropertyName);
+                        case Operator.Ne: return Restrictions.IsNotNull(property.PropertyName);
+                    }   
                 }
+                else
+                { 
+                    switch (expression.Operator)
+                    {
+                        case Operator.Eq: return Restrictions.IsNull(left);
+                        case Operator.Ne: return Restrictions.IsNotNull(left);
+                    }
+                }
+
+                throw new NotSupportedException();
             }
 
             left = ProjectionVisitor.CreateProjection(expression.Left);

--- a/NHibernate.OData/DynamicComponentProperty.cs
+++ b/NHibernate.OData/DynamicComponentProperty.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NHibernate.OData
+{
+    internal class DynamicComponentProperty
+    {
+        public string Name { get; private set; }
+        public System.Type Type { get; private set; }
+
+        public DynamicComponentProperty(string name, System.Type type)
+        {
+            Require.NotNull(name, "name");
+            Require.NotNull(type, "type");
+
+            Name = name;
+            Type = type;
+        }
+    }
+}

--- a/NHibernate.OData/MappedClassMetadata.cs
+++ b/NHibernate.OData/MappedClassMetadata.cs
@@ -10,8 +10,8 @@ namespace NHibernate.OData
 {
     internal class MappedClassMetadata
     {
-        private readonly IDictionary<string, DynamicComponentProperty> caseSensitiveDynamicProperties = new Dictionary<string, DynamicComponentProperty>(StringComparer.Ordinal);
-        private readonly IDictionary<string, DynamicComponentProperty> caseInsensitiveDynamicProperties = new Dictionary<string, DynamicComponentProperty>(StringComparer.OrdinalIgnoreCase);
+        private readonly IDictionary<string, DynamicComponentProperty> _caseSensitiveDynamicProperties = new Dictionary<string, DynamicComponentProperty>(StringComparer.Ordinal);
+        private readonly IDictionary<string, DynamicComponentProperty> _caseInsensitiveDynamicProperties = new Dictionary<string, DynamicComponentProperty>(StringComparer.OrdinalIgnoreCase);
 
         public MappedClassMetadata(IClassMetadata classMetadata)
         {
@@ -25,7 +25,7 @@ namespace NHibernate.OData
         {
             Require.NotNull(fullPath, "fullPath");
 
-            var dictionary = caseSensitive ? caseSensitiveDynamicProperties : caseInsensitiveDynamicProperties;
+            var dictionary = caseSensitive ? _caseSensitiveDynamicProperties : _caseInsensitiveDynamicProperties;
             DynamicComponentProperty dynamicProperty;
 
             dictionary.TryGetValue(fullPath, out dynamicProperty);
@@ -43,14 +43,14 @@ namespace NHibernate.OData
 
             for (int i = 0; i < component.PropertyNames.Length; i++)
             {
-                string fullName = string.Concat(name, ".", component.PropertyNames[i]);
+                string fullName = name + "." + component.PropertyNames[i];
 
                 if (isDynamicComponent)
                 {
                     var dynamicProperty = new DynamicComponentProperty(component.PropertyNames[i], component.Subtypes[i].ReturnedClass);
 
-                    caseInsensitiveDynamicProperties[fullName] = dynamicProperty;
-                    caseSensitiveDynamicProperties[fullName] = dynamicProperty;
+                    _caseInsensitiveDynamicProperties[fullName] = dynamicProperty;
+                    _caseSensitiveDynamicProperties[fullName] = dynamicProperty;
                 }
 
                 BuildDynamicComponentPropertyList(fullName, component.Subtypes[i]);

--- a/NHibernate.OData/MappedClassMetadata.cs
+++ b/NHibernate.OData/MappedClassMetadata.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NHibernate.Metadata;
+using NHibernate.Type;
+
+namespace NHibernate.OData
+{
+    internal class MappedClassMetadata
+    {
+        private readonly IDictionary<string, DynamicComponentProperty> caseSensitiveDynamicProperties = new Dictionary<string, DynamicComponentProperty>(StringComparer.Ordinal);
+        private readonly IDictionary<string, DynamicComponentProperty> caseInsensitiveDynamicProperties = new Dictionary<string, DynamicComponentProperty>(StringComparer.OrdinalIgnoreCase);
+
+        public MappedClassMetadata(IClassMetadata classMetadata)
+        {
+            Require.NotNull(classMetadata, "classMetadata");
+
+            for (int i = 0; i < classMetadata.PropertyNames.Length; i++)
+                BuildDynamicComponentPropertyList(classMetadata.PropertyNames[i], classMetadata.PropertyTypes[i]);
+        }
+
+        public DynamicComponentProperty FindDynamicComponentProperty(string fullPath, bool caseSensitive)
+        {
+            Require.NotNull(fullPath, "fullPath");
+
+            var dictionary = caseSensitive ? caseSensitiveDynamicProperties : caseInsensitiveDynamicProperties;
+            DynamicComponentProperty dynamicProperty;
+
+            dictionary.TryGetValue(fullPath, out dynamicProperty);
+
+            return dynamicProperty;
+        }
+
+        private void BuildDynamicComponentPropertyList(string name, IType type)
+        {
+            ComponentType component = type as ComponentType;
+            if (component == null)
+                return;
+
+            bool isDynamicComponent = component.ReturnedClass == typeof(IDictionary);
+
+            for (int i = 0; i < component.PropertyNames.Length; i++)
+            {
+                string fullName = string.Concat(name, ".", component.PropertyNames[i]);
+
+                if (isDynamicComponent)
+                {
+                    var dynamicProperty = new DynamicComponentProperty(component.PropertyNames[i], component.Subtypes[i].ReturnedClass);
+
+                    caseInsensitiveDynamicProperties[fullName] = dynamicProperty;
+                    caseSensitiveDynamicProperties[fullName] = dynamicProperty;
+                }
+
+                BuildDynamicComponentPropertyList(fullName, component.Subtypes[i]);
+            }
+        }
+    }
+}

--- a/NHibernate.OData/NHibernate.OData.csproj
+++ b/NHibernate.OData/NHibernate.OData.csproj
@@ -57,6 +57,7 @@
     <Compile Include="ArgumentType.cs" />
     <Compile Include="CriterionMethodVisitor.cs" />
     <Compile Include="CriterionVisitor.cs" />
+    <Compile Include="DynamicComponentProperty.cs" />
     <Compile Include="ErrorMessages.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -72,6 +73,7 @@
     <Compile Include="HttpUtil.cs" />
     <Compile Include="IMethodVisitor.cs" />
     <Compile Include="Inflector.cs" />
+    <Compile Include="MappedClassMetadata.cs" />
     <Compile Include="NormalizeVisitor.cs" />
     <Compile Include="ODataContext.cs" />
     <Compile Include="ODataParserConfiguration.cs" />

--- a/NHibernate.OData/ODataSessionFactoryContext.cs
+++ b/NHibernate.OData/ODataSessionFactoryContext.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Iesi.Collections.Generic;
+using NHibernate.Type;
 
 namespace NHibernate.OData
 {
@@ -10,20 +11,21 @@ namespace NHibernate.OData
     {
         internal static ODataSessionFactoryContext Empty = new ODataSessionFactoryContext();
 
-        public ISet<System.Type> MappedClasses { get; private set; }
+        public IDictionary<System.Type, MappedClassMetadata> MappedClassMetadata { get; private set; }
 
         private ODataSessionFactoryContext()
         {
-            MappedClasses = new ReadOnlySet<System.Type>(new HashSet<System.Type>());
+            MappedClassMetadata = new Dictionary<System.Type, MappedClassMetadata>();
         }
 
         public ODataSessionFactoryContext(ISessionFactory sessionFactory)
         {
             Require.NotNull(sessionFactory, "sessionFactory");
 
-            MappedClasses = new ReadOnlySet<System.Type>(new HashSet<System.Type>(
-                sessionFactory.GetAllClassMetadata().Values.Select(x => x.GetMappedClass(EntityMode.Poco))
-            ));
+            MappedClassMetadata = sessionFactory.GetAllClassMetadata().Values.ToDictionary(
+                x => x.GetMappedClass(EntityMode.Poco), 
+                x => new MappedClassMetadata(x)
+            );
         }
     }
 }


### PR DESCRIPTION
I added support for [dynamic components](http://nhibernate.info/doc/nh/en/index.html#components-dynamic).

Since a dynamic component may contain many-to-one associations, I search through NHibernate class mappings for dynamic components and their properties. The results are stored in the `MappedClassMetadata` class.

When an `IDictionary` member is encountered during member expression resolving in `AliasingNormalizeVisitor`, I look for an appropriate dynamic property in the `MappedClassMetadata` instance and if it's found, return that property's type and name.

Then, as usual, if the resolved type is a mapped class, a join is created.