### PR TITLE
'any' and 'all' collection methods

### DIFF
--- a/NHibernate.OData.Test/Criterions/CollectionMethods.cs
+++ b/NHibernate.OData.Test/Criterions/CollectionMethods.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NHibernate.OData.Test.Domain;
+using NHibernate.OData.Test.Support;
+using NUnit.Framework;
+
+namespace NHibernate.OData.Test.Criterions
+{
+    [TestFixture]
+    internal class CollectionMethods : DomainTestFixture
+    {
+        [Test]
+        public void AnyWithoutCondition()
+        {
+            Verify(
+                "RelatedParents/any()",
+                Session.QueryOver<Parent>().Where(x => x.Name == "Parent 9" || x.Name == "Parent 10").List()
+            );
+        }
+
+        [Test]
+        public void AllWithoutConditionFails()
+        {
+            VerifyThrows<Parent>("RelatedParents/all()", typeof(ODataException));
+        }
+    }
+}

--- a/NHibernate.OData.Test/Criterions/CollectionMethods.cs
+++ b/NHibernate.OData.Test/Criterions/CollectionMethods.cs
@@ -49,11 +49,16 @@ namespace NHibernate.OData.Test.Criterions
         }
 
         [Test]
-        public void OuterScopeVariable()
+        public void RootScopeVariable()
         {
             Verify(
                 "RelatedParents/any(x:x/Int32 eq $it/Int32 sub 8)",
                 Session.QueryOver<Parent>().Where(x => x.Name == "Parent 9").List()
+            );
+
+            Verify(
+                "RelatedParents/any(x:x/RelatedParents/any(y:y/Int32 eq $it/Int32 sub 6))",
+                Session.QueryOver<Parent>().Where(x => x.Name == "Parent 10").List()
             );
         }
 

--- a/NHibernate.OData.Test/Criterions/CollectionMethods.cs
+++ b/NHibernate.OData.Test/Criterions/CollectionMethods.cs
@@ -83,5 +83,28 @@ namespace NHibernate.OData.Test.Criterions
                 Session.QueryOver<Parent>().Where(x => x.Name == "Parent 10").List()
             );
         }
+
+        [Test]
+        public void AllWithSimpleCondition()
+        {
+            Verify(
+                "RelatedParents/all(x:x/Int32 ge 5)",
+                Session.QueryOver<Parent>().Where(x => x.Name != "Parent 9").List()
+            );
+
+            Verify(
+                "RelatedParents/all(x:x/Int32 ge 999)",
+                Session.QueryOver<Parent>().Where(x => x.Name != "Parent 9" && x.Name != "Parent 10").List()
+            );
+        }
+
+        [Test]
+        public void AllWithJoin()
+        {
+            Verify(
+                "RelatedParents/All(x:x/Child/Int32 ge 5)",
+                Session.QueryOver<Parent>().Where(x => x.Name != "Parent 9").List()
+            );
+        }
     }
 }

--- a/NHibernate.OData.Test/Criterions/CollectionMethods.cs
+++ b/NHibernate.OData.Test/Criterions/CollectionMethods.cs
@@ -111,5 +111,23 @@ namespace NHibernate.OData.Test.Criterions
                 Session.QueryOver<Parent>().Where(x => x.Name != "Parent 9").List()
             );
         }
+
+        [Test]
+        public void JoinToCollectionAny()
+        {
+            Verify(
+                "Child/RelatedParents/any()",
+                Session.QueryOver<Parent>().Where(x => x.Name != "Parent 1" && x.Name != "Parent 11").List()
+            );
+        }
+
+        [Test]
+        public void JoinToCollectionAnyWithItemJoin()
+        {
+            Verify(
+                "Child/RelatedParents/any(x:x/Child/Int32 ge 5)",
+                Session.QueryOver<Parent>().Where(x => x.Int32 >= 6 && x.Int32 <= 10).List()
+            );
+        }
     }
 }

--- a/NHibernate.OData.Test/Criterions/CollectionMethods.cs
+++ b/NHibernate.OData.Test/Criterions/CollectionMethods.cs
@@ -25,5 +25,63 @@ namespace NHibernate.OData.Test.Criterions
         {
             VerifyThrows<Parent>("RelatedParents/all()", typeof(ODataException));
         }
+
+        [Test]
+        public void AnyWithSimpleCondition()
+        {
+            Verify(
+                "RelatedParents/any(x:x/Int32 lt 5)",
+                Session.QueryOver<Parent>().Where(x => x.Name == "Parent 9").List()
+            );
+        }
+
+        [Test]
+        public void ThrowsOnDuplicateLambdaParameters()
+        {
+            VerifyThrows<Parent>("RelatedParents/any(x:x/RelatedParents/any(x:x/Int32 gt 0))", typeof(ODataException));
+            VerifyThrows<Parent>("RelatedParents/any($it:$it ne null)", typeof(ODataException));
+        }
+
+        [Test]
+        public void ThrowsOnNonCollection()
+        {
+            VerifyThrows<Parent>("Int32/any()", typeof(ODataException));
+        }
+
+        [Test]
+        public void OuterScopeVariable()
+        {
+            Verify(
+                "RelatedParents/any(x:x/Int32 eq $it/Int32 sub 8)",
+                Session.QueryOver<Parent>().Where(x => x.Name == "Parent 9").List()
+            );
+        }
+
+        [Test]
+        public void NestedAny()
+        {
+            Verify(
+                "RelatedParents/any(x:x/RelatedParents/any())",
+                Session.QueryOver<Parent>().Where(x => x.Name == "Parent 10").List()
+            );
+        }
+
+        [Test]
+        public void JoinInLambda()
+        {
+            Verify(
+                "RelatedParents/Any(x:x/Child/Int32 eq 3)",
+                Session.QueryOver<Parent>().Where(x => x.Name == "Parent 9").List()
+            );
+        }
+
+        [Test]
+        public void NestedAnyWithJoin()
+        {
+            Verify(
+                "RelatedParents/any(x:x/RelatedParents/any(y:y/Child/Int32 eq 2))",
+                Session.QueryOver<Parent>().Where(x => x.Name == "Parent 10").List()
+            );
+        }
     }
 }

--- a/NHibernate.OData.Test/Criterions/ImplicitVariable.cs
+++ b/NHibernate.OData.Test/Criterions/ImplicitVariable.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NHibernate.OData.Test.Domain;
+using NHibernate.OData.Test.Support;
+using NUnit.Framework;
+
+namespace NHibernate.OData.Test.Criterions
+{
+    [TestFixture]
+    internal class ImplicitVariable : DomainTestFixture
+    {
+        [Test]
+        public void SimpleQuery()
+        {
+            Verify("$filter=$it/Int32 eq 2", Session.QueryOver<Parent>().Where(x => x.Int32 == 2).List());
+        }
+
+        [Test]
+        public void ThrowsOnEmptyMemberExpression()
+        {
+            VerifyThrows<ODataException>("$filter=$it");
+        }
+    }
+}

--- a/NHibernate.OData.Test/Domain/Child.cs
+++ b/NHibernate.OData.Test/Domain/Child.cs
@@ -18,6 +18,8 @@ namespace NHibernate.OData.Test.Domain
 
         public virtual IDictionary DynamicComponent { get; set; }
 
+        public virtual ISet<Parent> RelatedParents { get; set; }
+
         public override string ToString()
         {
             return Name;

--- a/NHibernate.OData.Test/Domain/Model.hbm.xml
+++ b/NHibernate.OData.Test/Domain/Model.hbm.xml
@@ -29,5 +29,9 @@
       <property name="DynamicInt" type="int"/>
       <many-to-one name="DynamicChildRef" class="Child"/>
     </dynamic-component>
+    <set name="RelatedParents" table="Child_RelatedParents">
+      <key column="ParentId"/>
+      <many-to-many column="RelatedParentId" class="Parent"/>
+    </set>
   </class>
 </hibernate-mapping>

--- a/NHibernate.OData.Test/Domain/Model.hbm.xml
+++ b/NHibernate.OData.Test/Domain/Model.hbm.xml
@@ -9,6 +9,10 @@
     <property name="LengthString" type="string" />
     <property name="DateTime" type="datetime" />
     <many-to-one name="Child" column="ChildId" />
+    <set name="RelatedParents">
+      <key column="ParentId"/>
+      <many-to-many column="RelatedParentId" class="Parent"/>
+    </set>
   </class>
   <class name="Child">
     <id name="Id" type="int">

--- a/NHibernate.OData.Test/Domain/Parent.cs
+++ b/NHibernate.OData.Test/Domain/Parent.cs
@@ -19,6 +19,8 @@ namespace NHibernate.OData.Test.Domain
 
         public virtual Child Child { get; set; }
 
+        public virtual ISet<Parent> RelatedParents { get; set; }
+
         public override string ToString()
         {
             return Name;

--- a/NHibernate.OData.Test/Inverse/Basics.cs
+++ b/NHibernate.OData.Test/Inverse/Basics.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NHibernate.OData.Test.Support;
+using NUnit.Framework;
+
+namespace NHibernate.OData.Test.Inverse
+{
+    [TestFixture]
+    internal class Basics : InverseTestFixture
+    {
+        [Test]
+        public void Not()
+        {
+            Verify(
+                "not A",
+                new MemberExpression(MemberType.Boolean, "A")
+            );
+
+            Verify(
+                "not(A and B)",
+                new ParenExpression(
+                    new LogicalExpression(
+                        Operator.And,
+                        new MemberExpression(MemberType.Boolean, "A"), 
+                        new MemberExpression(MemberType.Boolean, "B")
+                    )
+                )
+            );
+        }
+
+        [Test]
+        public void Comparison()
+        {
+            Verify("A gt 2", new ComparisonExpression(Operator.Le, new MemberExpression(MemberType.Normal, "A"), new LiteralExpression(2)));
+            Verify("A ge 2", new ComparisonExpression(Operator.Lt, new MemberExpression(MemberType.Normal, "A"), new LiteralExpression(2)));
+            Verify("A lt 2", new ComparisonExpression(Operator.Ge, new MemberExpression(MemberType.Normal, "A"), new LiteralExpression(2)));
+            Verify("A le 2", new ComparisonExpression(Operator.Gt, new MemberExpression(MemberType.Normal, "A"), new LiteralExpression(2)));
+        }
+
+        [Test]
+        public void BoolMembersAnd()
+        {
+            Verify(
+                "A and B",
+                new LogicalExpression(
+                    Operator.Or,
+                    new BoolUnaryExpression(Operator.Not, new MemberExpression(MemberType.Boolean, "A")),
+                    new BoolUnaryExpression(Operator.Not, new MemberExpression(MemberType.Boolean, "B"))
+                )
+            );
+        }
+
+        [Test]
+        public void And()
+        {
+            Verify(
+                "A gt 2 and B",
+                new LogicalExpression(
+                    Operator.Or,
+                    new ComparisonExpression(
+                        Operator.Le,
+                        new MemberExpression(MemberType.Normal, "A"),
+                        new LiteralExpression(2)
+                    ), 
+                    new BoolUnaryExpression(
+                        Operator.Not, 
+                        new MemberExpression(MemberType.Normal, "B")
+                    )
+                )
+            );
+        }
+
+        [Test]
+        public void ComplexLogic()
+        {
+            Verify(
+                "A and B or not C",
+                new LogicalExpression(
+                    Operator.And, 
+                    new LogicalExpression(
+                        Operator.Or,
+                        new BoolUnaryExpression(
+                            Operator.Not,
+                            new MemberExpression(MemberType.Normal, "A")
+                        ), 
+                        new BoolUnaryExpression(
+                            Operator.Not,
+                            new MemberExpression(MemberType.Normal, "B")
+                        )
+                    ),
+                    new MemberExpression(MemberType.Normal, "C")
+                )
+            );
+        }
+
+        [Test]
+        public void MethodCall()
+        {
+            Verify(
+                "substringof('Test', A)",
+                new BoolUnaryExpression(
+                    Operator.Not,
+                    new MethodCallExpression(
+                        MethodCallType.Boolean,
+                        Method.SubStringOfMethod,
+                        new LiteralExpression("Test"),
+                        new MemberExpression(MemberType.Normal, "A")
+                    )
+                )
+            );
+        }
+    }
+}

--- a/NHibernate.OData.Test/NHibernate.OData.Test.csproj
+++ b/NHibernate.OData.Test/NHibernate.OData.Test.csproj
@@ -62,6 +62,7 @@
   <ItemGroup>
     <Compile Include="Criterions\Arithmetics.cs" />
     <Compile Include="Criterions\Casting.cs" />
+    <Compile Include="Criterions\ImplicitVariable.cs" />
     <Compile Include="Criterions\CollectionMethods.cs" />
     <Compile Include="Criterions\Comparisons.cs" />
     <Compile Include="Criterions\DynamicComponents.cs" />

--- a/NHibernate.OData.Test/NHibernate.OData.Test.csproj
+++ b/NHibernate.OData.Test/NHibernate.OData.Test.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Domain\IEntity.cs" />
     <Compile Include="Interface\EntityNameInterface.cs" />
     <Compile Include="Interface\ParsedQueryString.cs" />
+    <Compile Include="Inverse\Basics.cs" />
     <Compile Include="Issues\Issue13Fixture.cs" />
     <Compile Include="Issues\Issue6Fixture.cs" />
     <Compile Include="Parser\CollectionMethodCalls.cs" />
@@ -97,6 +98,7 @@
     <Compile Include="Pagings\Paging.cs" />
     <Compile Include="SupportFixtures\TypeUtil.cs" />
     <Compile Include="Support\DomainTestFixture.cs" />
+    <Compile Include="Support\InverseTestFixture.cs" />
     <Compile Include="Support\LexerTestFixture.cs" />
     <Compile Include="Parser\Basics.cs" />
     <Compile Include="Parser\Comparison.cs" />

--- a/NHibernate.OData.Test/NHibernate.OData.Test.csproj
+++ b/NHibernate.OData.Test/NHibernate.OData.Test.csproj
@@ -62,6 +62,7 @@
   <ItemGroup>
     <Compile Include="Criterions\Arithmetics.cs" />
     <Compile Include="Criterions\Casting.cs" />
+    <Compile Include="Criterions\CollectionMethods.cs" />
     <Compile Include="Criterions\Comparisons.cs" />
     <Compile Include="Criterions\DynamicComponents.cs" />
     <Compile Include="Criterions\Components.cs" />
@@ -94,6 +95,7 @@
     <Compile Include="Normalization\Strings.cs" />
     <Compile Include="OrderBys\OrderBy.cs" />
     <Compile Include="Pagings\Paging.cs" />
+    <Compile Include="SupportFixtures\TypeUtil.cs" />
     <Compile Include="Support\DomainTestFixture.cs" />
     <Compile Include="Support\LexerTestFixture.cs" />
     <Compile Include="Parser\Basics.cs" />

--- a/NHibernate.OData.Test/NHibernate.OData.Test.csproj
+++ b/NHibernate.OData.Test/NHibernate.OData.Test.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Interface\ParsedQueryString.cs" />
     <Compile Include="Issues\Issue13Fixture.cs" />
     <Compile Include="Issues\Issue6Fixture.cs" />
+    <Compile Include="Parser\CollectionMethodCalls.cs" />
     <Compile Include="SupportFixtures\HttpUtil.cs" />
     <Compile Include="Interface\IllegalQueryString.cs" />
     <Compile Include="Interface\NoFilter.cs" />

--- a/NHibernate.OData.Test/Normalization/Arithmetics.cs
+++ b/NHibernate.OData.Test/Normalization/Arithmetics.cs
@@ -132,15 +132,15 @@ namespace NHibernate.OData.Test.Normalization
                 "A add B",
                 new ArithmeticExpression(
                     Operator.Add,
-                    new ResolvedMemberExpression(MemberType.Normal, "A"),
-                    new ResolvedMemberExpression(MemberType.Normal, "B")
+                    new ResolvedMemberExpression(MemberType.Normal, "A", null),
+                    new ResolvedMemberExpression(MemberType.Normal, "B", null)
                 )
             );
             Verify(
                 "- A",
                 new ArithmeticUnaryExpression(
                     Operator.Negative,
-                    new ResolvedMemberExpression(MemberType.Normal, "A")
+                    new ResolvedMemberExpression(MemberType.Normal, "A", null)
                 )
             );
         }

--- a/NHibernate.OData.Test/Normalization/Comparisons.cs
+++ b/NHibernate.OData.Test/Normalization/Comparisons.cs
@@ -87,8 +87,8 @@ namespace NHibernate.OData.Test.Normalization
                 "A eq B",
                 new ComparisonExpression(
                     Operator.Eq,
-                    new ResolvedMemberExpression(MemberType.Normal, "A"),
-                    new ResolvedMemberExpression(MemberType.Normal, "B")
+                    new ResolvedMemberExpression(MemberType.Normal, "A", null),
+                    new ResolvedMemberExpression(MemberType.Normal, "B", null)
                 )
             );
         }

--- a/NHibernate.OData.Test/Normalization/IsOfs.cs
+++ b/NHibernate.OData.Test/Normalization/IsOfs.cs
@@ -27,7 +27,7 @@ namespace NHibernate.OData.Test.Normalization
                 new MethodCallExpression(
                     MethodCallType.Boolean,
                     Method.IsOfMethod,
-                    new ResolvedMemberExpression(MemberType.Normal, "A"),
+                    new ResolvedMemberExpression(MemberType.Normal, "A", null),
                     new LiteralExpression("Edm.Int32")
                 )
             );

--- a/NHibernate.OData.Test/Normalization/Logicals.cs
+++ b/NHibernate.OData.Test/Normalization/Logicals.cs
@@ -42,15 +42,15 @@ namespace NHibernate.OData.Test.Normalization
                 "not A",
                 new BoolUnaryExpression(
                     Operator.Not,
-                    new ResolvedMemberExpression(MemberType.Boolean, "A")
+                    new ResolvedMemberExpression(MemberType.Boolean, "A", null)
                 )
             );
             Verify(
                 "A or B",
                 new LogicalExpression(
                     Operator.Or,
-                    new ResolvedMemberExpression(MemberType.Normal, "A"),
-                    new ResolvedMemberExpression(MemberType.Normal, "B")
+                    new ResolvedMemberExpression(MemberType.Normal, "A", null),
+                    new ResolvedMemberExpression(MemberType.Normal, "B", null)
                 )
             );
         }

--- a/NHibernate.OData.Test/Parser/CollectionMethodCalls.cs
+++ b/NHibernate.OData.Test/Parser/CollectionMethodCalls.cs
@@ -133,9 +133,16 @@ namespace NHibernate.OData.Test.Parser
         public void IllegalCalls()
         {
             VerifyThrows("any()");
-            VerifyThrows("Collection/any");
-
             VerifyThrows("Collection/all()"); // An argument is required
+            VerifyThrows("Collection/any(");
+            VerifyThrows("Collection/any()/OtherMember");
+        }
+
+        [Test]
+        public void NotCollectionMethodCall()
+        {
+            Verify("A/any", new MemberExpression(MemberType.Normal, "A", "any"));
+            Verify("A/all/B", new MemberExpression(MemberType.Normal, "A", "all", "B"));
         }
     }
 }

--- a/NHibernate.OData.Test/Parser/CollectionMethodCalls.cs
+++ b/NHibernate.OData.Test/Parser/CollectionMethodCalls.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NHibernate.OData.Test.Support;
+using NUnit.Framework;
+
+namespace NHibernate.OData.Test.Parser
+{
+    [TestFixture]
+    internal class CollectionMethodCalls : ParserTestFixture
+    {      
+        [Test]
+        public void CollectionAny()
+        {
+            Verify(
+                "Collection/any()",
+                new MethodCallExpression(
+                    MethodCallType.Boolean,
+                    Method.AnyMethod,
+                    new MemberExpression(MemberType.Normal, "Collection")
+                )
+            );
+        }
+
+        [Test]
+        public void Parenthesis()
+        {
+            Verify(
+                "(Collection/any())",
+                new ParenExpression(
+                    new MethodCallExpression(
+                        MethodCallType.Boolean,
+                        Method.AnyMethod,
+                        new MemberExpression(MemberType.Normal, "Collection")
+                    )
+                )
+            );            
+        }
+
+        [Test]
+        public void CollectionAnyWithSimplePredicate()
+        {
+            Verify(
+                "Collection/any(x : x/Bool)",
+                new MethodCallExpression(
+                    MethodCallType.Boolean,
+                    Method.AnyMethod,
+                    new MemberExpression(MemberType.Normal, "Collection"),
+                    new LambdaExpression(
+                        "x",
+                        new MemberExpression(MemberType.Normal, "x", "Bool")
+                    )
+                )
+            );
+        }
+
+        [Test]
+        public void CollectionAnyWithNestedCollectionAll()
+        {
+            Verify(
+                "Collection/any(x : x/OtherCollection/all(y:y/Bool))",
+                new MethodCallExpression(
+                    MethodCallType.Boolean,
+                    Method.AnyMethod,
+                    new MemberExpression(MemberType.Normal, "Collection"),
+                    new LambdaExpression(
+                        "x",
+                        new MethodCallExpression(
+                            MethodCallType.Boolean, 
+                            Method.AllMethod,
+                            new MemberExpression(MemberType.Normal, "x", "OtherCollection"),
+                            new LambdaExpression(
+                                "y",
+                                new MemberExpression(MemberType.Normal, "y", "Bool")
+                            )
+                        )
+                    )
+                )
+            );
+        }
+
+        [Test]
+        public void CollectionAnyWithComplexPredicate()
+        {
+            Verify(
+                "Collection/any(x: x/A eq 1 or x/B)",
+                new MethodCallExpression(
+                    MethodCallType.Boolean,
+                    Method.AnyMethod,
+                    new MemberExpression(MemberType.Normal, "Collection"),
+                    new LambdaExpression(
+                        "x",
+                        new LogicalExpression(
+                            Operator.Or,
+                            new ComparisonExpression(Operator.Eq, new MemberExpression(MemberType.Normal, "x", "A"),  new LiteralExpression(1)), 
+                            new MemberExpression(MemberType.Boolean, "x", "B")
+                        )
+                    )
+                )
+            );
+        }
+
+        [Test]
+        public void CollectionAnyInsideLogicExpression()
+        {
+            Verify(
+                "A and Collection/any() or B",
+                new LogicalExpression(
+                    Operator.Or, 
+                    new LogicalExpression(
+                        Operator.And,
+                        new MemberExpression(MemberType.Boolean, "A"),
+                        new MethodCallExpression(
+                            MethodCallType.Boolean,
+                            Method.AnyMethod,
+                            new MemberExpression(MemberType.Normal, "Collection")
+                        )
+                    ),
+                    new MemberExpression(MemberType.Boolean, "B")
+                )
+            );
+        }
+
+        [Test]
+        public void InvalidLambda()
+        {
+            VerifyThrows("Collection/any(x)");
+            VerifyThrows("Collection/any(x:)");
+        }
+
+        [Test]
+        public void IllegalCalls()
+        {
+            VerifyThrows("any()");
+            VerifyThrows("Collection/any");
+
+            VerifyThrows("Collection/all()"); // An argument is required
+        }
+    }
+}

--- a/NHibernate.OData.Test/Support/DomainTestFixture.cs
+++ b/NHibernate.OData.Test/Support/DomainTestFixture.cs
@@ -79,7 +79,8 @@ namespace NHibernate.OData.Test.Support
                             { "DynamicString", "Value " + i },
                             { "DynamicInt", i },
                             { "DynamicChildRef", previousChild },
-                        }
+                        },
+                        RelatedParents = new HashSet<Parent>(parents),
                     };
 
                     if (i == 10)

--- a/NHibernate.OData.Test/Support/DomainTestFixture.cs
+++ b/NHibernate.OData.Test/Support/DomainTestFixture.cs
@@ -60,6 +60,7 @@ namespace NHibernate.OData.Test.Support
                 string lengthString = "";
 
                 Child previousChild = null;
+                var parents = new List<Parent>();
 
                 for (int i = 1; i <= 10; i++)
                 {
@@ -89,14 +90,22 @@ namespace NHibernate.OData.Test.Support
 
                     session.Save(child);
 
-                    session.Save(new Parent
+                    var parent = new Parent
                     {
                         Name = "Parent " + i,
                         Int32 = i,
                         Child = child,
                         LengthString = lengthString,
                         DateTime = new DateTime(2000 + i, i, i, i, i, i)
-                    });
+                    };
+
+                    if (i == 9)
+                        parent.RelatedParents = new HashSet<Parent>(parents.Where(x => x.Int32 < 5));
+                    if (i == 10)
+                        parent.RelatedParents = new HashSet<Parent>(parents.Where(x => x.Int32 >= 5));
+
+                    session.Save(parent);
+                    parents.Add(parent);
 
                     previousChild = child;
                 }
@@ -108,6 +117,8 @@ namespace NHibernate.OData.Test.Support
                     LengthString = lengthString,
                     DateTime = new DateTime(2000 + 11, 11, 11, 11, 11, 11)
                 });
+
+                session.Flush();
             }
         }
 

--- a/NHibernate.OData.Test/Support/InverseTestFixture.cs
+++ b/NHibernate.OData.Test/Support/InverseTestFixture.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NHibernate.OData.Test.Support
+{
+    internal abstract class InverseTestFixture : ParserTestFixture
+    {
+        protected override void Verify(Expression actual, Expression expected)
+        {
+            base.Verify(InverseVisitor.Invert(actual), expected);
+        }
+
+        protected override Expression VerifyThrows(Expression expression)
+        {
+            return InverseVisitor.Invert(expression);
+        }
+    }
+}

--- a/NHibernate.OData.Test/Support/NormalizedTestFixture.cs
+++ b/NHibernate.OData.Test/Support/NormalizedTestFixture.cs
@@ -9,7 +9,7 @@ namespace NHibernate.OData.Test.Support
     {
         protected override void Verify(Expression actual, Expression expected)
         {
-            base.Verify(actual.Visit(new AliasingNormalizeVisitor(new CriterionBuildContext(ODataSessionFactoryContext.Empty),  null, true, null)), expected);
+            base.Verify(actual.Visit(new AliasingNormalizeVisitor(new CriterionBuildContext(ODataSessionFactoryContext.Empty, true), null, null)), expected);
         }
 
         protected void Verify(string source, object value)
@@ -22,7 +22,7 @@ namespace NHibernate.OData.Test.Support
 
         protected override Expression VerifyThrows(Expression expression)
         {
-            return expression.Visit(new AliasingNormalizeVisitor(new CriterionBuildContext(ODataSessionFactoryContext.Empty), null, true, null));
+            return expression.Visit(new AliasingNormalizeVisitor(new CriterionBuildContext(ODataSessionFactoryContext.Empty, true), null, null));
         }
     }
 }

--- a/NHibernate.OData.Test/Support/NormalizedTestFixture.cs
+++ b/NHibernate.OData.Test/Support/NormalizedTestFixture.cs
@@ -9,7 +9,7 @@ namespace NHibernate.OData.Test.Support
     {
         protected override void Verify(Expression actual, Expression expected)
         {
-            base.Verify(actual.Visit(new AliasingNormalizeVisitor(ODataSessionFactoryContext.Empty,  null, true)), expected);
+            base.Verify(actual.Visit(new AliasingNormalizeVisitor(new CriterionBuildContext(ODataSessionFactoryContext.Empty),  null, true, null)), expected);
         }
 
         protected void Verify(string source, object value)
@@ -22,7 +22,7 @@ namespace NHibernate.OData.Test.Support
 
         protected override Expression VerifyThrows(Expression expression)
         {
-            return expression.Visit(new AliasingNormalizeVisitor(ODataSessionFactoryContext.Empty, null, true));
+            return expression.Visit(new AliasingNormalizeVisitor(new CriterionBuildContext(ODataSessionFactoryContext.Empty), null, true, null));
         }
     }
 }

--- a/NHibernate.OData.Test/SupportFixtures/TypeUtil.cs
+++ b/NHibernate.OData.Test/SupportFixtures/TypeUtil.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+
+namespace NHibernate.OData.Test.SupportFixtures
+{
+    [TestFixture]
+    internal class TypeUtil
+    {
+        [Test]
+        public void CollectionTypes()
+        {
+            Assert.AreEqual(typeof(int), OData.TypeUtil.TryGetCollectionItemType(typeof(List<int>)));
+            Assert.AreEqual(typeof(int), OData.TypeUtil.TryGetCollectionItemType(typeof(ISet<int>)));
+            Assert.AreEqual(null, OData.TypeUtil.TryGetCollectionItemType(typeof(IEnumerable)));
+        }
+    }
+}

--- a/NHibernate.OData/Alias.cs
+++ b/NHibernate.OData/Alias.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NHibernate.OData
+{
+    internal class Alias
+    {
+        public string Name { get; private set; }
+        public string AssociationPath { get; private set; }
+        public System.Type ReturnedType { get; private set; }
+
+        public Alias(string name, string associationPath, System.Type returnedType)
+        {
+            Require.NotEmpty(name, "name");
+            Require.NotNull(associationPath, "associationPath");
+            Require.NotNull(returnedType, "returnedType");
+
+            Name = name;
+            AssociationPath = associationPath;
+            ReturnedType = returnedType;
+        }
+    }
+}

--- a/NHibernate.OData/AliasingNormalizeVisitor.cs
+++ b/NHibernate.OData/AliasingNormalizeVisitor.cs
@@ -42,7 +42,7 @@ namespace NHibernate.OData
                 {
                     var lambdaContext = _context.FindLambdaContext(members[0].Name);
                     if (lambdaContext == null)
-                        throw new QueryException("Member expressions inside a lambda expression must start with a lambda parameter");
+                        throw new QueryException(ErrorMessages.Expression_LambdaMemberMustStartWithParameter);
 
                     type = lambdaContext.ParameterType;
                     lastAliasName = lambdaContext.ParameterAlias;
@@ -123,7 +123,7 @@ namespace NHibernate.OData
 
                 if (dynamicProperty == null)
                     throw new QueryException(String.Format(
-                        "Cannot resolve member '{0}' of dynamic component '{1}' on '{2}'", name, mappedClassPath, type
+                        ErrorMessages.Resolve_CannotResolveDynamicComponentMember, name, mappedClassPath, type
                     ));
 
                 type = dynamicProperty.Type;
@@ -152,7 +152,7 @@ namespace NHibernate.OData
             }
 
             throw new QueryException(String.Format(
-                "Cannot resolve name '{0}' on '{1}'", name, type)
+                ErrorMessages.Resolve_CannotResolveName, name, type)
             );
         }
     }

--- a/NHibernate.OData/AliasingNormalizeVisitor.cs
+++ b/NHibernate.OData/AliasingNormalizeVisitor.cs
@@ -97,6 +97,7 @@ namespace NHibernate.OData
                     {
                         alias = new Alias(_context.CreateUniqueAliasName(), path, type);
                         Aliases.Add(path, alias);
+                        _context.AddAlias(alias);
                     }
 
                     lastAliasName = alias.Name;

--- a/NHibernate.OData/CriterionBuildContext.cs
+++ b/NHibernate.OData/CriterionBuildContext.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace NHibernate.OData
+{
+    internal class CriterionBuildContext
+    {
+        public ODataSessionFactoryContext SessionFactoryContext { get; private set; }
+        public IDictionary<string, Alias> AliasesByName { get; private set; }
+
+        private int _aliasCounter;
+
+        public CriterionBuildContext(ODataSessionFactoryContext sessionFactoryContext)
+        {
+            Require.NotNull(sessionFactoryContext, "sessionFactoryContext");
+
+            SessionFactoryContext = sessionFactoryContext;
+            AliasesByName = new Dictionary<string, Alias>();
+        }
+
+        public void AddAliases(IEnumerable<Alias> aliasesToAdd)
+        {
+            foreach (var alias in aliasesToAdd)
+                AliasesByName.Add(alias.Name, alias);
+        }
+
+        public string CreateUniqueAliasName()
+        {
+            return "t" + (++_aliasCounter).ToString(CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/NHibernate.OData/CriterionBuildContext.cs
+++ b/NHibernate.OData/CriterionBuildContext.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 
 namespace NHibernate.OData
 {
@@ -10,26 +9,65 @@ namespace NHibernate.OData
     {
         public ODataSessionFactoryContext SessionFactoryContext { get; private set; }
         public IDictionary<string, Alias> AliasesByName { get; private set; }
+        public bool CaseSensitive { get; private set; }
+
+        public bool IsInsideLambdaContext
+        {
+            get { return _lambdaContextStack.Count != 0; }
+        }
 
         private int _aliasCounter;
 
-        public CriterionBuildContext(ODataSessionFactoryContext sessionFactoryContext)
+        private readonly Stack<LambdaExpressionContext> _lambdaContextStack = new Stack<LambdaExpressionContext>();
+
+        public CriterionBuildContext(ODataSessionFactoryContext sessionFactoryContext, bool caseSensitive)
         {
             Require.NotNull(sessionFactoryContext, "sessionFactoryContext");
 
             SessionFactoryContext = sessionFactoryContext;
-            AliasesByName = new Dictionary<string, Alias>();
+            CaseSensitive = caseSensitive;
+
+            AliasesByName = new Dictionary<string, Alias>(StringComparer.Ordinal);
         }
 
         public void AddAliases(IEnumerable<Alias> aliasesToAdd)
         {
+            Require.NotNull(aliasesToAdd, "aliasesToAdd");
+
             foreach (var alias in aliasesToAdd)
-                AliasesByName.Add(alias.Name, alias);
+                AddAlias(alias);
+        }
+
+        public void AddAlias(Alias alias)
+        {
+            Require.NotNull(alias, "alias");
+
+            AliasesByName.Add(alias.Name, alias);
         }
 
         public string CreateUniqueAliasName()
         {
             return "t" + (++_aliasCounter).ToString(CultureInfo.InvariantCulture);
+        }
+
+        public void PushLambdaContext(LambdaExpression lambdaExpression, System.Type parameterType, string parameterAlias)
+        {
+            if (lambdaExpression.ParameterName == "$it" || _lambdaContextStack.Any(x => x.Expression.ParameterName.Equals(lambdaExpression.ParameterName, StringComparison.Ordinal)))
+                throw new ODataException(string.Format("Lambda expression parameter '{0}' has been already defined in the parent scope.", lambdaExpression.ParameterName));
+
+            _lambdaContextStack.Push(new LambdaExpressionContext(lambdaExpression, parameterType, parameterAlias));
+        }
+
+        public void PopLambdaContext()
+        {
+            _lambdaContextStack.Pop();
+        }
+
+        public LambdaExpressionContext FindLambdaContext(string parameterName)
+        {
+            Require.NotNull(parameterName, "parameterName");
+
+            return _lambdaContextStack.FirstOrDefault(x => x.Expression.ParameterName.Equals(parameterName, StringComparison.Ordinal));
         }
     }
 }

--- a/NHibernate.OData/CriterionMethodVisitor.cs
+++ b/NHibernate.OData/CriterionMethodVisitor.cs
@@ -137,7 +137,7 @@ namespace NHibernate.OData
                 if (method.MethodType == MethodType.All)
                     lambdaExpression = (LambdaExpression)InverseVisitor.Invert(lambdaExpression);
 
-                _context.PushLambdaContext(lambdaExpression, itemType, lambdaAlias);
+                _context.PushLambdaContext(lambdaExpression.ParameterName, itemType, lambdaAlias);
 
                 try
                 {

--- a/NHibernate.OData/CriterionMethodVisitor.cs
+++ b/NHibernate.OData/CriterionMethodVisitor.cs
@@ -3,20 +3,24 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using NHibernate.Criterion;
+using NHibernate.SqlCommand;
 
 namespace NHibernate.OData
 {
     internal class CriterionMethodVisitor : QueryMethodVisitorBase<ICriterion>
     {
-        private static readonly CriterionMethodVisitor _instance = new CriterionMethodVisitor();
+        private readonly CriterionBuildContext _context;
 
-        private CriterionMethodVisitor()
+        public CriterionMethodVisitor(CriterionBuildContext context)
         {
+            Require.NotNull(context, "context");
+
+            _context = context;
         }
 
-        public static ICriterion CreateCriterion(Method method, Expression[] arguments)
+        public ICriterion CreateCriterion(Method method, Expression[] arguments)
         {
-            return method.Visit(_instance, arguments);
+            return method.Visit(this, arguments);
         }
 
         public override ICriterion SubStringOfMethod(SubStringOfMethod method, Expression[] arguments)
@@ -53,6 +57,69 @@ namespace NHibernate.OData
                 LiteralUtil.CoerceString(((LiteralExpression)arguments[1])),
                 MatchMode.End
             );
+        }
+
+        public override ICriterion AnyMethod(AnyMethod method, Expression[] arguments)
+        {
+            if (arguments[0].Type != ExpressionType.ResolvedMember)
+                return base.AnyMethod(method, arguments);
+
+            LambdaExpression lambdaExpression;
+
+            if (arguments.Length < 2)
+                lambdaExpression = null;
+            else if (arguments[1].Type == ExpressionType.Lambda)
+                lambdaExpression = (LambdaExpression)arguments[1];
+            else
+                return base.AnyMethod(method, arguments);
+
+            var resolvedMember = (ResolvedMemberExpression)arguments[0];
+            /*System.Type itemType;
+
+            if (resolvedMember.Type == null || (itemType = TypeUtil.TryGetCollectionItemType(resolvedMember.Type)) == null)
+                throw new ODataException("Cannot get collection item type");*/
+
+            // Resolved member's name may contain multiple dots if it's inside a component (i.e. 'root.Component.Collection')
+            int p = resolvedMember.Member.IndexOf('.');
+            if (p == -1)
+                throw new ODataException(string.Format("Member '{0}' must have an alias.", resolvedMember.Member));
+
+            var collectionHolderAliasName = resolvedMember.Member.Substring(0, p);
+            var collectionMemberName = resolvedMember.Member.Substring(p + 1);
+
+            Alias collectionHolderAlias;
+            _context.AliasesByName.TryGetValue(collectionHolderAliasName, out collectionHolderAlias);
+
+            if (collectionHolderAlias == null)
+                throw new ODataException(string.Format("Unknown alias '{0}'.", collectionHolderAliasName));
+
+            var subCriteriaAlias = _context.CreateUniqueAliasName();
+            var detachedCriteria = DetachedCriteria.For(collectionHolderAlias.ReturnedType, subCriteriaAlias);
+
+            MappedClassMetadata metadata;
+            _context.SessionFactoryContext.MappedClassMetadata.TryGetValue(collectionHolderAlias.ReturnedType, out metadata);
+
+            if (metadata == null)
+                throw new ODataException(string.Format("The type '{0}' isn't a NHibernate-mapped class.", collectionHolderAlias.ReturnedType.FullName));
+            if (metadata.IdentifierPropertyName == null)
+                throw new ODataException(string.Format("The type '{0}' doesn't have an identifier property.", collectionHolderAlias.ReturnedType.FullName));
+
+            detachedCriteria.Add(Restrictions.EqProperty(
+                subCriteriaAlias + "." + metadata.IdentifierPropertyName,
+                collectionHolderAliasName + "." + metadata.IdentifierPropertyName
+            ));
+
+            var lambdaAlias = _context.CreateUniqueAliasName();
+
+            // The inner joined alias to collection items must be created in any case (whether the lambda expression is specified or not)
+            detachedCriteria.CreateAlias(subCriteriaAlias + "." + collectionMemberName, lambdaAlias, JoinType.InnerJoin);
+
+            detachedCriteria.SetProjection(Projections.Constant(1));
+
+            if (lambdaExpression != null)
+                throw new NotImplementedException("Lambda expression support is not implemented yet");
+
+            return Subqueries.Exists(detachedCriteria);
         }
     }
 }

--- a/NHibernate.OData/CriterionMethodVisitor.cs
+++ b/NHibernate.OData/CriterionMethodVisitor.cs
@@ -143,7 +143,7 @@ namespace NHibernate.OData
                 {
                     var lambdaNormalizeVisitor = new AliasingNormalizeVisitor(
                         _context,
-                        _context.AliasesByName[collectionHolderAliasName].ReturnedType,
+                        collectionHolderAlias.ReturnedType,
                         collectionHolderAliasName
                     );
 

--- a/NHibernate.OData/CriterionVisitor.cs
+++ b/NHibernate.OData/CriterionVisitor.cs
@@ -8,15 +8,18 @@ namespace NHibernate.OData
 {
     internal class CriterionVisitor : QueryVisitorBase<ICriterion>
     {
-        private static readonly CriterionVisitor _instance = new CriterionVisitor();
+        private readonly CriterionBuildContext _context;
 
-        private CriterionVisitor()
+        public CriterionVisitor(CriterionBuildContext context)
         {
+            Require.NotNull(context, "context");
+
+            _context = context;
         }
 
-        public static ICriterion CreateCriterion(Expression expression)
+        public ICriterion CreateCriterion(Expression expression)
         {
-            return expression.Visit(_instance);
+            return expression.Visit(this);
         }
 
         public override ICriterion ComparisonExpression(ComparisonExpression expression)
@@ -115,7 +118,7 @@ namespace NHibernate.OData
 
         public override ICriterion MethodCallExpression(MethodCallExpression expression)
         {
-            return CriterionMethodVisitor.CreateCriterion(expression.Method, expression.Arguments);
+            return new CriterionMethodVisitor(_context).CreateCriterion(expression.Method, expression.Arguments);
         }
     }
 }

--- a/NHibernate.OData/ErrorMessages.Designer.cs
+++ b/NHibernate.OData/ErrorMessages.Designer.cs
@@ -97,6 +97,15 @@ namespace NHibernate.OData {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Member expressions inside a lambda expression must start with a lambda parameter.
+        /// </summary>
+        internal static string Expression_LambdaMemberMustStartWithParameter {
+            get {
+                return ResourceManager.GetString("Expression_LambdaMemberMustStartWithParameter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unexpected exponent for decimal literal at {0}..
         /// </summary>
         internal static string Lexer_DecimalCannotHaveExponent {
@@ -462,6 +471,24 @@ namespace NHibernate.OData {
         internal static string PathParser_InvalidPath {
             get {
                 return ResourceManager.GetString("PathParser_InvalidPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot resolve member &apos;{0}&apos; of dynamic component &apos;{1}&apos; on &apos;{2}&apos;.
+        /// </summary>
+        internal static string Resolve_CannotResolveDynamicComponentMember {
+            get {
+                return ResourceManager.GetString("Resolve_CannotResolveDynamicComponentMember", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot resolve name &apos;{0}&apos; on &apos;{1}&apos;.
+        /// </summary>
+        internal static string Resolve_CannotResolveName {
+            get {
+                return ResourceManager.GetString("Resolve_CannotResolveName", resourceCulture);
             }
         }
     }

--- a/NHibernate.OData/ErrorMessages.Designer.cs
+++ b/NHibernate.OData/ErrorMessages.Designer.cs
@@ -304,6 +304,15 @@ namespace NHibernate.OData {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot parse lambda expression..
+        /// </summary>
+        internal static string Parser_CannotParseLambdaExpression {
+            get {
+                return ResourceManager.GetString("Parser_CannotParseLambdaExpression", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unexpected empty expression..
         /// </summary>
         internal static string Parser_EmptySource {
@@ -426,6 +435,15 @@ namespace NHibernate.OData {
         internal static string Parser_UnexpectedEnd {
             get {
                 return ResourceManager.GetString("Parser_UnexpectedEnd", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unknown collection method &apos;{0}&apos;..
+        /// </summary>
+        internal static string Parser_UnknownCollectionMethod {
+            get {
+                return ResourceManager.GetString("Parser_UnknownCollectionMethod", resourceCulture);
             }
         }
         

--- a/NHibernate.OData/ErrorMessages.Designer.cs
+++ b/NHibernate.OData/ErrorMessages.Designer.cs
@@ -106,6 +106,15 @@ namespace NHibernate.OData {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Lambda expression parameter &apos;{0}&apos; has been already defined in the parent scope..
+        /// </summary>
+        internal static string Expression_LambdaParameterIsAlreadyDefined {
+            get {
+                return ResourceManager.GetString("Expression_LambdaParameterIsAlreadyDefined", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unexpected exponent for decimal literal at {0}..
         /// </summary>
         internal static string Lexer_DecimalCannotHaveExponent {

--- a/NHibernate.OData/ErrorMessages.resx
+++ b/NHibernate.OData/ErrorMessages.resx
@@ -261,4 +261,7 @@
   <data name="Resolve_CannotResolveName" xml:space="preserve">
     <value>Cannot resolve name '{0}' on '{1}'</value>
   </data>
+  <data name="Expression_LambdaParameterIsAlreadyDefined" xml:space="preserve">
+    <value>Lambda expression parameter '{0}' has been already defined in the parent scope.</value>
+  </data>
 </root>

--- a/NHibernate.OData/ErrorMessages.resx
+++ b/NHibernate.OData/ErrorMessages.resx
@@ -252,4 +252,13 @@
   <data name="Parser_CannotParseLambdaExpression" xml:space="preserve">
     <value>Cannot parse lambda expression.</value>
   </data>
+  <data name="Expression_LambdaMemberMustStartWithParameter" xml:space="preserve">
+    <value>Member expressions inside a lambda expression must start with a lambda parameter</value>
+  </data>
+  <data name="Resolve_CannotResolveDynamicComponentMember" xml:space="preserve">
+    <value>Cannot resolve member '{0}' of dynamic component '{1}' on '{2}'</value>
+  </data>
+  <data name="Resolve_CannotResolveName" xml:space="preserve">
+    <value>Cannot resolve name '{0}' on '{1}'</value>
+  </data>
 </root>

--- a/NHibernate.OData/ErrorMessages.resx
+++ b/NHibernate.OData/ErrorMessages.resx
@@ -243,7 +243,13 @@
   <data name="Parser_UnknownMethod" xml:space="preserve">
     <value>Unknown method '{0}'.</value>
   </data>
+  <data name="Parser_UnknownCollectionMethod" xml:space="preserve">
+    <value>Unknown collection method '{0}'.</value>
+  </data>
   <data name="PathParser_InvalidPath" xml:space="preserve">
     <value>Could not parse path.</value>
+  </data>
+  <data name="Parser_CannotParseLambdaExpression" xml:space="preserve">
+    <value>Cannot parse lambda expression.</value>
   </data>
 </root>

--- a/NHibernate.OData/Expression.cs
+++ b/NHibernate.OData/Expression.cs
@@ -184,18 +184,21 @@ namespace NHibernate.OData
 
     internal class ResolvedMemberExpression : Expression
     {
-        public ResolvedMemberExpression(MemberType memberType, string member)
+        public ResolvedMemberExpression(MemberType memberType, string member, System.Type returnedType)
             : base(ExpressionType.ResolvedMember)
         {
             Require.NotNull(member, "member");
 
             Member = member;
             MemberType = memberType;
+            ReturnedType = returnedType;
         }
 
         public string Member { get; private set; }
 
         public MemberType MemberType { get; private set; }
+
+        public System.Type ReturnedType { get; private set; }
 
         public override bool IsBool
         {
@@ -217,7 +220,8 @@ namespace NHibernate.OData
             return
                 other != null &&
                 Member == other.Member &&
-                IsBool == other.IsBool;
+                IsBool == other.IsBool &&
+                ReturnedType == other.ReturnedType;
         }
 
         public override string ToString()
@@ -542,7 +546,7 @@ namespace NHibernate.OData
 
         public override T Visit<T>(IVisitor<T> visitor)
         {
-            throw new NotImplementedException();
+            return visitor.LambdaExpression(this);
         }
 
         public override bool Equals(object obj)

--- a/NHibernate.OData/Expression.cs
+++ b/NHibernate.OData/Expression.cs
@@ -519,4 +519,52 @@ namespace NHibernate.OData
         Normal,
         Boolean
     }
+
+    internal class LambdaExpression : Expression
+    {
+        public string ParameterName { get; private set; }
+        public Expression Body { get; private set; }
+
+        public override bool IsBool
+        {
+            get { return true; }
+        }
+
+        public LambdaExpression(string parameterName, Expression body)
+            : base(ExpressionType.Lambda)
+        {
+            Require.NotEmpty(parameterName, "parameterName");
+            Require.NotNull(body, "body");
+
+            ParameterName = parameterName;
+            Body = ExpressionUtil.CoerceBoolExpression(body);
+        }
+
+        public override T Visit<T>(IVisitor<T> visitor)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(this, obj))
+                return true;
+
+            var other = obj as LambdaExpression;
+
+            if (
+                other == null ||
+                !ParameterName.Equals(other.ParameterName, StringComparison.Ordinal) ||
+                !Body.Equals(other.Body)
+            )
+                return false;
+
+            return true;
+        }
+
+        public override string ToString()
+        {
+            return string.Format("({0}: {1})", ParameterName, Body);
+        }
+    }
 }

--- a/NHibernate.OData/ExpressionType.cs
+++ b/NHibernate.OData/ExpressionType.cs
@@ -18,6 +18,7 @@ namespace NHibernate.OData
         Member,
         Paren,
         ArithmeticUnary,
-        ResolvedMember
+        ResolvedMember,
+        Lambda
     }
 }

--- a/NHibernate.OData/ExpressionUtil.cs
+++ b/NHibernate.OData/ExpressionUtil.cs
@@ -25,7 +25,7 @@ namespace NHibernate.OData
                         return new MemberExpression(MemberType.Boolean, ((MemberExpression)expression).Members);
 
                     case ExpressionType.ResolvedMember:
-                        return new ResolvedMemberExpression(MemberType.Boolean, ((ResolvedMemberExpression)expression).Member);
+                        return new ResolvedMemberExpression(MemberType.Boolean, ((ResolvedMemberExpression)expression).Member, ((ResolvedMemberExpression)expression).ReturnedType);
 
                     default:
                         throw new ODataException(ErrorMessages.Parser_ExpectedBooleanExpression);

--- a/NHibernate.OData/IMethodVisitor.cs
+++ b/NHibernate.OData/IMethodVisitor.cs
@@ -50,5 +50,9 @@ namespace NHibernate.OData
         TResult FloorMethod(FloorMethod method, TArg arg);
 
         TResult CeilingMethod(CeilingMethod method, TArg arg);
+
+        TResult AnyMethod(AnyMethod method, TArg arg);
+
+        TResult AllMethod(AllMethod method, TArg arg);
     }
 }

--- a/NHibernate.OData/IVisitor.cs
+++ b/NHibernate.OData/IVisitor.cs
@@ -26,5 +26,7 @@ namespace NHibernate.OData
         T MethodCallExpression(MethodCallExpression expression);
 
         T ResolvedMemberExpression(ResolvedMemberExpression expression);
+
+        T LambdaExpression(LambdaExpression expression);
     }
 }

--- a/NHibernate.OData/InverseVisitor.cs
+++ b/NHibernate.OData/InverseVisitor.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NHibernate.OData
+{
+    internal class InverseVisitor : IVisitor<Expression>
+    {
+        private static readonly InverseVisitor _instance = new InverseVisitor();
+
+        private InverseVisitor()
+        {
+        }
+
+        public static Expression Invert(Expression expression)
+        {
+            return expression.Visit(_instance);
+        }
+
+        public Expression BoolUnaryExpression(BoolUnaryExpression expression)
+        {
+            if (expression.Operator != Operator.Not)
+                throw new NotSupportedException();
+
+            return expression.Expression;
+        }
+
+        public Expression LogicalExpression(LogicalExpression expression)
+        {
+            Operator op = expression.Operator;
+
+            switch (op)
+            {
+                case Operator.And: op = Operator.Or; break;
+                case Operator.Or: op = Operator.And; break;
+                default:
+                    throw new NotSupportedException();
+            }
+
+            return new LogicalExpression(op, expression.Left.Visit(this), expression.Right.Visit(this));
+        }
+
+        public Expression ComparisonExpression(ComparisonExpression expression)
+        {
+            Operator op = expression.Operator;
+
+            switch (op)
+            {
+                case Operator.Gt: op = Operator.Le; break;
+                case Operator.Ge: op = Operator.Lt; break;
+                case Operator.Lt: op = Operator.Ge; break;
+                case Operator.Le: op = Operator.Gt; break;
+                case Operator.Eq: op = Operator.Ne; break;
+                case Operator.Ne: op = Operator.Eq; break;
+                default:
+                    throw new NotSupportedException();
+            }
+
+            return new ComparisonExpression(op, expression.Left.Visit(this), expression.Right.Visit(this));
+        }
+
+        public Expression MethodCallExpression(MethodCallExpression expression)
+        {
+            var args = expression.Arguments.Select(x => x.Visit(this)).ToArray();
+            var methodCallExpr = new MethodCallExpression(expression.MethodCallType, expression.Method, args);
+
+            if (methodCallExpr.IsBool)
+                return new BoolUnaryExpression(Operator.Not, methodCallExpr);
+               
+            return methodCallExpr;
+        }
+
+        public Expression LiteralExpression(LiteralExpression expression)
+        {
+            return expression;
+        }
+
+        public Expression MemberExpression(MemberExpression expression)
+        {
+            if (expression.IsBool)
+                return new BoolUnaryExpression(Operator.Not, expression);
+
+            return expression;
+        }
+
+        public Expression ResolvedMemberExpression(ResolvedMemberExpression expression)
+        {
+            return expression;
+        }
+
+        public Expression ParenExpression(ParenExpression expression)
+        {
+            return expression.Expression.Visit(this);
+        }
+
+        public Expression ArithmeticUnaryExpression(ArithmeticUnaryExpression expression)
+        {
+            return new ArithmeticUnaryExpression(expression.Operator, expression.Expression.Visit(this));
+        }
+
+        public Expression ArithmeticExpression(ArithmeticExpression expression)
+        {
+            return new ArithmeticExpression(expression.Operator, expression.Left.Visit(this), expression.Right.Visit(this));
+        }
+
+        public Expression LambdaExpression(LambdaExpression expression)
+        {
+            return new LambdaExpression(expression.ParameterName, expression.Body.Visit(this));
+        }
+    }
+}

--- a/NHibernate.OData/LambdaExpressionContext.cs
+++ b/NHibernate.OData/LambdaExpressionContext.cs
@@ -7,17 +7,17 @@ namespace NHibernate.OData
 {
     internal class LambdaExpressionContext
     {
-        public LambdaExpression Expression { get; private set; }
+        public string ParameterName { get; private set; }
         public System.Type ParameterType { get; private set; }
         public string ParameterAlias { get; private set; }
 
-        public LambdaExpressionContext(LambdaExpression expression, System.Type parameterType, string parameterAlias)
+        public LambdaExpressionContext(string parameterName, System.Type parameterType, string parameterAlias)
         {
-            Require.NotNull(expression, "expression");
+            Require.NotEmpty(parameterName, "parameterName");
             Require.NotNull(parameterType, "parameterType");
             Require.NotEmpty(parameterAlias, "parameterAlias");
 
-            Expression = expression;
+            ParameterName = parameterName;
             ParameterType = parameterType;
             ParameterAlias = parameterAlias;
         }

--- a/NHibernate.OData/LambdaExpressionContext.cs
+++ b/NHibernate.OData/LambdaExpressionContext.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NHibernate.OData
+{
+    internal class LambdaExpressionContext
+    {
+        public LambdaExpression Expression { get; private set; }
+        public System.Type ParameterType { get; private set; }
+        public string ParameterAlias { get; private set; }
+
+        public LambdaExpressionContext(LambdaExpression expression, System.Type parameterType, string parameterAlias)
+        {
+            Require.NotNull(expression, "expression");
+            Require.NotNull(parameterType, "parameterType");
+            Require.NotEmpty(parameterAlias, "parameterAlias");
+
+            Expression = expression;
+            ParameterType = parameterType;
+            ParameterAlias = parameterAlias;
+        }
+    }
+}

--- a/NHibernate.OData/Lexer.cs
+++ b/NHibernate.OData/Lexer.cs
@@ -69,6 +69,7 @@ namespace NHibernate.OData
                 case ')':
                 case ',':
                 case '/':
+                case ':':
                     return ParseSyntax();
 
                 default:
@@ -328,6 +329,7 @@ namespace NHibernate.OData
                 case ')': token = SyntaxToken.ParenClose; break;
                 case '/': token = SyntaxToken.Slash; break;
                 case ',': token = SyntaxToken.Comma; break;
+                case ':': token = SyntaxToken.Colon; break;
                 default: throw new InvalidOperationException("Unknown token");
             }
 

--- a/NHibernate.OData/MappedClassMetadata.cs
+++ b/NHibernate.OData/MappedClassMetadata.cs
@@ -13,12 +13,16 @@ namespace NHibernate.OData
         private readonly IDictionary<string, DynamicComponentProperty> _caseSensitiveDynamicProperties = new Dictionary<string, DynamicComponentProperty>(StringComparer.Ordinal);
         private readonly IDictionary<string, DynamicComponentProperty> _caseInsensitiveDynamicProperties = new Dictionary<string, DynamicComponentProperty>(StringComparer.OrdinalIgnoreCase);
 
+        public string IdentifierPropertyName { get; private set; }
+
         public MappedClassMetadata(IClassMetadata classMetadata)
         {
             Require.NotNull(classMetadata, "classMetadata");
 
             for (int i = 0; i < classMetadata.PropertyNames.Length; i++)
                 BuildDynamicComponentPropertyList(classMetadata.PropertyNames[i], classMetadata.PropertyTypes[i]);
+
+            IdentifierPropertyName = classMetadata.IdentifierPropertyName;
         }
 
         public DynamicComponentProperty FindDynamicComponentProperty(string fullPath, bool caseSensitive)

--- a/NHibernate.OData/Method.cs
+++ b/NHibernate.OData/Method.cs
@@ -446,7 +446,7 @@ namespace NHibernate.OData
 
         public override TResult Visit<TResult, TArg>(IMethodVisitor<TResult, TArg> visitor, TArg arg)
         {
-            throw new NotImplementedException();
+            return visitor.AnyMethod(this, arg);
         }
     }
 
@@ -459,7 +459,7 @@ namespace NHibernate.OData
 
         public override TResult Visit<TResult, TArg>(IMethodVisitor<TResult, TArg> visitor, TArg arg)
         {
-            throw new NotImplementedException();
+            return visitor.AllMethod(this, arg);
         }
     }
 }

--- a/NHibernate.OData/Method.cs
+++ b/NHibernate.OData/Method.cs
@@ -31,6 +31,8 @@ namespace NHibernate.OData
         public static readonly RoundMethod RoundMethod = new RoundMethod();
         public static readonly FloorMethod FloorMethod = new FloorMethod();
         public static readonly CeilingMethod CeilingMethod = new CeilingMethod();
+        public static readonly AnyMethod AnyMethod = new AnyMethod();
+        public static readonly AllMethod AllMethod = new AllMethod();
 
         private static readonly Dictionary<MethodType, Method> _methods = new Dictionary<MethodType,Method>
         {
@@ -55,7 +57,9 @@ namespace NHibernate.OData
             { MethodType.Second, SecondMethod },
             { MethodType.Round, RoundMethod },
             { MethodType.Floor, FloorMethod },
-            { MethodType.Ceiling, CeilingMethod }
+            { MethodType.Ceiling, CeilingMethod },
+            { MethodType.Any, AnyMethod },
+            { MethodType.All, AllMethod }
         };
 
         private static readonly Dictionary<string, MethodType> _methodNames = CreateMethodNames();
@@ -422,6 +426,40 @@ namespace NHibernate.OData
         public override TResult Visit<TResult, TArg>(IMethodVisitor<TResult, TArg> visitor, TArg arg)
         {
             return visitor.CeilingMethod(this, arg);
+        }
+    }
+
+    internal abstract class CollectionMethod : Method
+    {
+        protected CollectionMethod(MethodType methodType, params ArgumentType[] argumentTypes)
+            : base(methodType, argumentTypes)
+        {
+        }
+    }
+
+    internal class AnyMethod : CollectionMethod
+    {
+        public AnyMethod()
+            : base(MethodType.Any, ArgumentType.Common, ArgumentType.OptionalCommon)
+        {
+        }
+
+        public override TResult Visit<TResult, TArg>(IMethodVisitor<TResult, TArg> visitor, TArg arg)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    internal class AllMethod : CollectionMethod
+    {
+        public AllMethod()
+            : base(MethodType.All, ArgumentType.Common, ArgumentType.Common)
+        {
+        }
+
+        public override TResult Visit<TResult, TArg>(IMethodVisitor<TResult, TArg> visitor, TArg arg)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/NHibernate.OData/MethodType.cs
+++ b/NHibernate.OData/MethodType.cs
@@ -28,6 +28,8 @@ namespace NHibernate.OData
         Second,
         Round,
         Floor,
-        Ceiling
+        Ceiling,
+        Any,
+        All
     }
 }

--- a/NHibernate.OData/NHibernate.OData.csproj
+++ b/NHibernate.OData/NHibernate.OData.csproj
@@ -75,6 +75,7 @@
     <Compile Include="HttpUtil.cs" />
     <Compile Include="IMethodVisitor.cs" />
     <Compile Include="Inflector.cs" />
+    <Compile Include="LambdaExpressionContext.cs" />
     <Compile Include="MappedClassMetadata.cs" />
     <Compile Include="NormalizeVisitor.cs" />
     <Compile Include="ODataContext.cs" />

--- a/NHibernate.OData/NHibernate.OData.csproj
+++ b/NHibernate.OData/NHibernate.OData.csproj
@@ -54,7 +54,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Alias.cs" />
     <Compile Include="ArgumentType.cs" />
+    <Compile Include="CriterionBuildContext.cs" />
     <Compile Include="CriterionMethodVisitor.cs" />
     <Compile Include="CriterionVisitor.cs" />
     <Compile Include="DynamicComponentProperty.cs" />
@@ -108,6 +110,7 @@
     <Compile Include="Token.cs" />
     <Compile Include="Lexer.cs" />
     <Compile Include="TokenType.cs" />
+    <Compile Include="TypeUtil.cs" />
     <Compile Include="XmlTimeSpan.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/NHibernate.OData/NHibernate.OData.csproj
+++ b/NHibernate.OData/NHibernate.OData.csproj
@@ -75,6 +75,7 @@
     <Compile Include="HttpUtil.cs" />
     <Compile Include="IMethodVisitor.cs" />
     <Compile Include="Inflector.cs" />
+    <Compile Include="InverseVisitor.cs" />
     <Compile Include="LambdaExpressionContext.cs" />
     <Compile Include="MappedClassMetadata.cs" />
     <Compile Include="NormalizeVisitor.cs" />

--- a/NHibernate.OData/NormalizeMethodVisitor.cs
+++ b/NHibernate.OData/NormalizeMethodVisitor.cs
@@ -408,5 +408,15 @@ namespace NHibernate.OData
         {
             return NormalizeFloatingPoint(method, arguments);
         }
+
+        public Expression AnyMethod(AnyMethod method, LiteralExpression[] arg)
+        {
+            throw new QueryNotSupportException();
+        }
+
+        public Expression AllMethod(AllMethod method, LiteralExpression[] arg)
+        {
+            throw new QueryNotSupportException();
+        }
     }
 }

--- a/NHibernate.OData/NormalizeVisitor.cs
+++ b/NHibernate.OData/NormalizeVisitor.cs
@@ -376,5 +376,10 @@ namespace NHibernate.OData
         {
             throw new InvalidOperationException();
         }
+
+        public Expression LambdaExpression(LambdaExpression expression)
+        {
+            return expression;
+        }
     }
 }

--- a/NHibernate.OData/ODataExpression.cs
+++ b/NHibernate.OData/ODataExpression.cs
@@ -31,6 +31,9 @@ namespace NHibernate.OData
 
             _context = new CriterionBuildContext(sessionFactoryContext, configuration.CaseSensitive);
             _context.AliasesByName.Add(RootAlias, new Alias(RootAlias, string.Empty, _persistentClass));
+
+            if (persistentClass != null)
+                _context.PushLambdaContext("$it", _persistentClass, RootAlias);
             
             _normalizeVisitor = new AliasingNormalizeVisitor(_context, persistentClass, RootAlias);
             _context.AddAliases(_normalizeVisitor.Aliases.Values);

--- a/NHibernate.OData/ODataExpression.cs
+++ b/NHibernate.OData/ODataExpression.cs
@@ -29,10 +29,10 @@ namespace NHibernate.OData
             _persistentClass = persistentClass;
             _configuration = configuration;
 
-            _context = new CriterionBuildContext(sessionFactoryContext);
+            _context = new CriterionBuildContext(sessionFactoryContext, configuration.CaseSensitive);
             _context.AliasesByName.Add(RootAlias, new Alias(RootAlias, string.Empty, _persistentClass));
             
-            _normalizeVisitor = new AliasingNormalizeVisitor(_context, persistentClass, configuration.CaseSensitive, RootAlias);
+            _normalizeVisitor = new AliasingNormalizeVisitor(_context, persistentClass, RootAlias);
             _context.AddAliases(_normalizeVisitor.Aliases.Values);
         }
 

--- a/NHibernate.OData/Parser.cs
+++ b/NHibernate.OData/Parser.cs
@@ -348,7 +348,10 @@ namespace NHibernate.OData
         {
             var identifier = Current as IdentifierToken;
 
-            return identifier != null && Method.FindMethodByName(identifier.Identifier) is CollectionMethod;
+            return 
+                identifier != null && 
+                Equals(Next, SyntaxToken.ParenOpen) &&
+                Method.FindMethodByName(identifier.Identifier) is CollectionMethod;
         }
 
         private MethodCallExpression ParseMethodCall()
@@ -471,7 +474,7 @@ namespace NHibernate.OData
 
             ValidateArgumentCount(method, arguments.Count);
 
-            MoveNext();
+            Expect(SyntaxToken.ParenClose);
 
             return new MethodCallExpression(
                 MethodCallType.Boolean,

--- a/NHibernate.OData/Parser.cs
+++ b/NHibernate.OData/Parser.cs
@@ -462,7 +462,7 @@ namespace NHibernate.OData
 
             ExpectAny();
 
-            List<Expression> arguments = new List<Expression>(2)
+            var arguments = new List<Expression>(2)
             {
                 new MemberExpression(MemberType.Normal, collectionMembers)
             };

--- a/NHibernate.OData/QueryMethodVisitorBase.cs
+++ b/NHibernate.OData/QueryMethodVisitorBase.cs
@@ -116,5 +116,15 @@ namespace NHibernate.OData
         {
             throw new QueryNotSupportException();
         }
+
+        public virtual TResult AnyMethod(AnyMethod method, Expression[] arg)
+        {
+            throw new QueryNotSupportException();
+        }
+
+        public virtual TResult AllMethod(AllMethod method, Expression[] arg)
+        {
+            throw new QueryNotSupportException();
+        }
     }
 }

--- a/NHibernate.OData/QueryVisitorBase.cs
+++ b/NHibernate.OData/QueryVisitorBase.cs
@@ -56,5 +56,10 @@ namespace NHibernate.OData
         {
             throw new QueryNotSupportException();
         }
+
+        public virtual T LambdaExpression(LambdaExpression expression)
+        {
+            throw new QueryNotSupportException();
+        }
     }
 }

--- a/NHibernate.OData/Token.cs
+++ b/NHibernate.OData/Token.cs
@@ -107,6 +107,7 @@ namespace NHibernate.OData
         public static readonly SyntaxToken Slash = new SyntaxToken('/');
         public static readonly SyntaxToken Comma = new SyntaxToken(',');
         public static readonly SyntaxToken Negative = new SyntaxToken('-');
+        public static readonly SyntaxToken Colon = new SyntaxToken(':');
 
         public char Syntax { get; private set; }
 

--- a/NHibernate.OData/TypeUtil.cs
+++ b/NHibernate.OData/TypeUtil.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NHibernate.OData
+{
+    internal static class TypeUtil
+    {
+        public static System.Type TryGetCollectionItemType(System.Type collectionType)
+        {
+            if (collectionType == null)
+                return null;
+
+            System.Type enumerableType = collectionType.GetInterfaces().FirstOrDefault(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+            if (enumerableType == null)
+                return null;
+
+            return enumerableType.GetGenericArguments().Single();
+        }
+    }
+}


### PR DESCRIPTION
I implemented `any` and `all` collection methods (`anyMethodCallExpression` and `allMethodCallExpression` as in OData 3.0 specification).

For testing purposes I added a many-to-many relation `RelatedParents` to the `Parent` domain class.

The both methods accept a lambda expression (`lambdaVariableExpression ":" lambdaPredicateExpression`) as a parameter (it's optional for `any` method). The lambda expression may contain complex expressions, joins and even other collection methods (see `CollectionMethodCalls` test fixture).

#### `CriterionBuildContext`
An instance of this class is created in the `ODataExpression` constructor and is passed into `AliasingNormalizeVisitor`, `CriterionMethodVisitor` and `CriterionVisitor`. Its purposes are:
* Creating unique alias names
* Keeping track of aliases created by different `AliasingNormalizeVisitor`s (see below)
* Keeping track of the lambda expression stack and current expression level

#### Simplified algorithm
0. The root criteria being built is assigned an alias `root`
1. When a collection method is encountered, the `CriterionMethodVisitor` creates a detached criteria on the current entity type
2. The detached criteria (DC) is assigned an unique alias by the `CriterionBuildContext`
3. A restriction is created in the DC: `[DC alias].[entity identifier property] = [parent alias].[entity identifier property]`. Identifier property name is extracted from NHibernate metadata.
4. An inner join to the collection item (CI) is created in the DC: `[CI alias] <=> [DC alias].[collection property name]`
5. The DC is set to return constant (1).
6. If the lambda expression was specified:
    1. If the method is `all`, the lambda expression body is logically inverted by `InverseVisitor`
    2. A lambda context (contains lambda parameter name, CI type and CI alias) is pushed into `CriterionBuildContext`'s lambda context stack.
    3. A new `AliasingNormalizeVisitor` is created with the CI alias as root and CI type as entity type.
    4. The lambda expression's body is processed by that `AliasingNormalizeVisitor`. It uses the current lambda context stack to resolve any encountered lambda variables in member expressions
    5. A new `CriterionVisitor` is created with the same `CriterionBuildContext` as current
    6. The lambda expression body is processed by that `CriterionBuildContext`
    7. The resulting criterion from `CriterionVisitor` and aliases from `AliasingNormalizeVisitor` are added into DC
    8. The current lambda context is popped from lambda context stack.
7. An `Exists` (for `any()`) or `Not Exists` (for `all()`) restriction is created using the DC.

#### Generated SQL for `any(x:x/SomeProperty gt 3)` on many-to-many relation (simplified)
```SQL
select ... from RootEntity as root
where exists (
    select 1
	from RootEntity as DCAlias
	inner join RelationTable as RT on RT.OwnerId = DCAlias.Id
	inner join CollectionItem as CIAlias on CIAlias.Id = RT.ItemId
	where DCAlias.Id = root.Id
	  -- Lambda expression:
	  and CIAlias.SomeProperty > 3
)
```

#### `all(...)` implementation
The `all` method is implemented as a direct inverse of `any` method (i.e. if `any(Int32 > 2)` becomes `exists(select 1 ... where Int32 > 2)` then `all(Int32 > 2)` gets inverted into `not exists(select 1 where ... Int32 <= 2)`).