### PR TITLE
Added "CaseSensitiveLike" configuration option

### DIFF
--- a/NHibernate.OData.Test/Criterions/Strings.cs
+++ b/NHibernate.OData.Test/Criterions/Strings.cs
@@ -58,6 +58,20 @@ namespace NHibernate.OData.Test.Criterions
             VerifyThrows<Parent>("endswith(LengthString, Name)");
         }
 
+        // SQLite has case insensitive LIKE by default; just test that CaseSensitiveLike option doen't throw
+        [Test]
+        public void InsensitiveLikeDoesNotThrow()
+        {
+            var configuration = new ODataParserConfiguration
+            {
+                CaseSensitiveLike = false
+            };
+
+            Verify<Parent>("substringof('cde', LengthString)", q => q.Where(p => p.LengthString.IsInsensitiveLike("cde", MatchMode.Anywhere)), configuration);
+            Verify<Parent>("startswith(LengthString, 'abcde')", q => q.Where(p => p.LengthString.IsInsensitiveLike("abcde", MatchMode.Start)), configuration);
+            Verify<Parent>("endswith(LengthString, 'cde')", q => q.Where(p => p.LengthString.IsInsensitiveLike("cde", MatchMode.End)), configuration);
+        }
+
         [Test]
         public void SubStringOfAndEndsWith()
         {

--- a/NHibernate.OData.Test/Support/DomainTestFixture.cs
+++ b/NHibernate.OData.Test/Support/DomainTestFixture.cs
@@ -204,6 +204,12 @@ namespace NHibernate.OData.Test.Support
             Verify(filter, query(Session.QueryOver<T>()).List());
         }
 
+        protected void Verify<T>(string filter, Func<IQueryOver<T, T>, IQueryOver<T, T>> query, ODataParserConfiguration configuration)
+            where T : class, IEntity
+        {
+            Verify(filter, query(Session.QueryOver<T>()).List(), configuration);
+        }
+
         protected void VerifyOrdered<T>(string filter, Func<IQueryOver<T, T>, IQueryOver<T, T>> query)
             where T : class, IEntity
         {

--- a/NHibernate.OData.Test/Support/NormalizedTestFixture.cs
+++ b/NHibernate.OData.Test/Support/NormalizedTestFixture.cs
@@ -9,7 +9,7 @@ namespace NHibernate.OData.Test.Support
     {
         protected override void Verify(Expression actual, Expression expected)
         {
-            base.Verify(actual.Visit(new AliasingNormalizeVisitor(new CriterionBuildContext(ODataSessionFactoryContext.Empty, true, new NameResolver()), null, null)), expected);
+            base.Verify(actual.Visit(new AliasingNormalizeVisitor(new CriterionBuildContext(ODataSessionFactoryContext.Empty, true, true, new NameResolver()), null, null)), expected);
         }
 
         protected void Verify(string source, object value)
@@ -22,7 +22,7 @@ namespace NHibernate.OData.Test.Support
 
         protected override Expression VerifyThrows(Expression expression)
         {
-            return expression.Visit(new AliasingNormalizeVisitor(new CriterionBuildContext(ODataSessionFactoryContext.Empty, true, new NameResolver()), null, null));
+            return expression.Visit(new AliasingNormalizeVisitor(new CriterionBuildContext(ODataSessionFactoryContext.Empty, true, true, new NameResolver()), null, null));
         }
     }
 }

--- a/NHibernate.OData/AliasingNormalizeVisitor.cs
+++ b/NHibernate.OData/AliasingNormalizeVisitor.cs
@@ -123,7 +123,7 @@ namespace NHibernate.OData
             {
                 string fullPath = mappedClassPath + "." + name;
 
-                var dynamicProperty = mappedClass.FindDynamicComponentProperty(fullPath, _context.CaseSensitive);
+                var dynamicProperty = mappedClass.FindDynamicComponentProperty(fullPath, _context.CaseSensitiveResolve);
 
                 if (dynamicProperty == null)
                     throw new QueryException(String.Format(
@@ -134,7 +134,7 @@ namespace NHibernate.OData
                 return dynamicProperty.Name;
             }
 
-            var resolvedName = _context.NameResolver.ResolveName(name, type, _context.CaseSensitive);
+            var resolvedName = _context.NameResolver.ResolveName(name, type, _context.CaseSensitiveResolve);
             if (resolvedName != null)
             {
                 type = resolvedName.Type;

--- a/NHibernate.OData/CriterionBuildContext.cs
+++ b/NHibernate.OData/CriterionBuildContext.cs
@@ -9,7 +9,8 @@ namespace NHibernate.OData
     {
         public ODataSessionFactoryContext SessionFactoryContext { get; private set; }
         public IDictionary<string, Alias> AliasesByName { get; private set; }
-        public bool CaseSensitive { get; private set; }
+        public bool CaseSensitiveResolve { get; private set; }
+        public bool CaseSensitiveLike { get; private set; }
         public NameResolver NameResolver { get; private set; }
 
         public int ExpressionLevel
@@ -21,13 +22,14 @@ namespace NHibernate.OData
 
         private readonly Stack<LambdaExpressionContext> _lambdaContextStack = new Stack<LambdaExpressionContext>();
 
-        public CriterionBuildContext(ODataSessionFactoryContext sessionFactoryContext, bool caseSensitive, NameResolver nameResolver)
+        public CriterionBuildContext(ODataSessionFactoryContext sessionFactoryContext, bool caseSensitiveResolve, bool caseSensitiveLike, NameResolver nameResolver)
         {
             Require.NotNull(sessionFactoryContext, "sessionFactoryContext");
             Require.NotNull(nameResolver, "nameResolver");
 
             SessionFactoryContext = sessionFactoryContext;
-            CaseSensitive = caseSensitive;
+            CaseSensitiveResolve = caseSensitiveResolve;
+            CaseSensitiveLike = caseSensitiveLike;
             NameResolver = nameResolver;
 
             AliasesByName = new Dictionary<string, Alias>(StringComparer.Ordinal);

--- a/NHibernate.OData/CriterionMethodVisitor.cs
+++ b/NHibernate.OData/CriterionMethodVisitor.cs
@@ -28,11 +28,7 @@ namespace NHibernate.OData
             if (arguments[0].Type != ExpressionType.Literal)
                 return base.SubStringOfMethod(method, arguments);
 
-            return Restrictions.Like(
-                ProjectionVisitor.CreateProjection(arguments[1]),
-                LiteralUtil.CoerceString(((LiteralExpression)arguments[0])),
-                MatchMode.Anywhere
-            );
+            return CreateLikeCriterion(arguments[1], arguments[0], MatchMode.Anywhere);
         }
 
         public override ICriterion StartsWithMethod(StartsWithMethod method, Expression[] arguments)
@@ -40,11 +36,7 @@ namespace NHibernate.OData
             if (arguments[1].Type != ExpressionType.Literal)
                 return base.StartsWithMethod(method, arguments);
 
-            return Restrictions.Like(
-                ProjectionVisitor.CreateProjection(arguments[0]),
-                LiteralUtil.CoerceString(((LiteralExpression)arguments[1])),
-                MatchMode.Start
-            );
+            return CreateLikeCriterion(arguments[0], arguments[1], MatchMode.Start);
         }
 
         public override ICriterion EndsWithMethod(EndsWithMethod method, Expression[] arguments)
@@ -52,11 +44,7 @@ namespace NHibernate.OData
             if (arguments[1].Type != ExpressionType.Literal)
                 return base.EndsWithMethod(method, arguments);
 
-            return Restrictions.Like(
-                ProjectionVisitor.CreateProjection(arguments[0]),
-                LiteralUtil.CoerceString(((LiteralExpression)arguments[1])),
-                MatchMode.End
-            );
+            return CreateLikeCriterion(arguments[0], arguments[1], MatchMode.End);
         }
 
         public override ICriterion AnyMethod(AnyMethod method, Expression[] arguments)
@@ -82,6 +70,14 @@ namespace NHibernate.OData
                 return base.AllMethod(method, arguments);
 
             return CreateAnyOrAllCriterion(method, (ResolvedMemberExpression)arguments[0], (LambdaExpression)arguments[1]);
+        }
+
+        private ICriterion CreateLikeCriterion(Expression projectionExpression, Expression literalExpression, MatchMode matchMode)
+        {
+            var projection = ProjectionVisitor.CreateProjection(projectionExpression);
+            var value = LiteralUtil.CoerceString((LiteralExpression)literalExpression);
+
+            return _context.CaseSensitiveLike ? Restrictions.Like(projection, value, matchMode) : Restrictions.InsensitiveLike(projection, value, matchMode);
         }
 
         private ICriterion CreateAnyOrAllCriterion(CollectionMethod method, ResolvedMemberExpression resolvedMember, LambdaExpression lambdaExpression)

--- a/NHibernate.OData/ODataExpression.cs
+++ b/NHibernate.OData/ODataExpression.cs
@@ -32,6 +32,7 @@ namespace NHibernate.OData
             _context = new CriterionBuildContext(
                 sessionFactoryContext,
                 configuration.CaseSensitive,
+                configuration.CaseSensitiveLike,
                 configuration.NameResolver ?? new NameResolver()
             );
             _context.AliasesByName.Add(RootAlias, new Alias(RootAlias, string.Empty, _persistentClass));

--- a/NHibernate.OData/ODataParserConfiguration.cs
+++ b/NHibernate.OData/ODataParserConfiguration.cs
@@ -16,6 +16,12 @@ namespace NHibernate.OData
         public bool CaseSensitive { get; set; }
 
         /// <summary>
+        /// Instructs NHibernate to use case sensitive (true) or case insensitive (false) LIKE expressions.
+        /// Actual support depends on the RDBMS of choice and NHibernate dialect.
+        /// </summary>
+        public bool CaseSensitiveLike { get; set; }
+
+        /// <summary>
         /// By default joins will be inner joins. Set this to true to use left outer joins.
         /// </summary>
         public bool OuterJoin { get; set; }
@@ -36,6 +42,7 @@ namespace NHibernate.OData
         public ODataParserConfiguration()
         {
             CaseSensitive = true;
+            CaseSensitiveLike = true;
         }
     }
 }


### PR DESCRIPTION
Hi!
I added `CaseSensitiveLike` configuration option (true by default) to support case insensitive LIKE operators for `substringof`, `startswith` and `endswith` methods.
See #21 